### PR TITLE
v1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.19.0]
 - JSON output was missing committer name and email
+- Fixed Gitlab rule which was incorrectly identifying certain tokens as valid
 
 ## [1.18.1]
 - Restored --version cli argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.19.0]
+- JSON output was missing committer name and email
 
 ## [1.18.1]
 - Restored --version cli argument

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [package]
 name = "kingfisher"
-version = "1.18.1"
+version = "1.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -159,7 +159,7 @@ rand = "0.9.1"
 percent-encoding = "2.3.1"
 trust-dns-resolver   = { version = "0.23.2", default-features = false, features = ["tokio-runtime"] }
 atty = "0.2.14"
-self_update = { version = "0.42.0", default-features = false, features = ["rustls"] }
+self_update = { version = "0.42.0", default-features = false, features = ["rustls", "archive-tar", "archive-zip", "compression-flate2"] }
 semver = "1.0.26"
 
 [dependencies.tikv-jemallocator]

--- a/data/rules/gitlab.yml
+++ b/data/rules/gitlab.yml
@@ -71,6 +71,11 @@ rules:
             - report_response: true
             - type: StatusMatch
               status: 200
+            - type: WordMatch
+              words:
+                - '"token is missing"'
+                - '"403 Forbidden"'
+              negative: true
           url: https://gitlab.com/api/v4/runners/verify
 
   - name: GitLab Pipeline Trigger Token
@@ -104,4 +109,9 @@ rules:
             - type: StatusMatch
               status: 
                 - 200
+            - type: WordMatch
+              words:
+                - '"token is missing"'
+                - '"403 Forbidden"'
+              negative: true
           url: https://gitlab.com/api/v4/ci/pipeline_triggers/{{ TOKEN }}

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -80,6 +80,10 @@ impl DetailsReporter {
                     "id": cmd.commit_id.to_string(),
                     "url": format!("{}/commit/{}", repo_url, cmd.commit_id),
                     "date": atime,
+                    "committer": {
+                        "name": String::from_utf8_lossy(&cmd.committer_name),
+                        "email": String::from_utf8_lossy(&cmd.committer_email),
+                    },
                     // "author": {
                     //     "name": String::from_utf8_lossy(&cmd.author_name),
                     //     "email": String::from_utf8_lossy(&cmd.author_email),

--- a/tests/smoke_update.rs
+++ b/tests/smoke_update.rs
@@ -5,6 +5,11 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
+use flate2::{write::GzEncoder, Compression};
+use tar::Builder;
+use tempfile::tempdir;
+use std::fs::{self, File};
+
 #[tokio::test]
 async fn no_update_when_flag_set() {
     let args = GlobalArgs { no_update_check: true, ..Default::default() };


### PR DESCRIPTION
- JSON output was missing committer name and email
- Fixed Gitlab rule which was incorrectly identifying certain tokens as valid