### PR TITLE
fix(digitalocean): regex is case-sensitive

### DIFF
--- a/data/rules/digitalocean.yml
+++ b/data/rules/digitalocean.yml
@@ -2,7 +2,7 @@ rules:
   - name: DigitalOcean API Key
     id: kingfisher.digitalocean.1
     pattern: |
-      (?xi)
+      (?x)
       \b
       (
         (?:dop|doo)_v1_
@@ -32,7 +32,7 @@ rules:
   - name: DigitalOcean Refresh Token
     id: kingfisher.digitalocean.2
     pattern: |
-      (?xi)
+      (?x)
       \b
       (
         dor_v1_


### PR DESCRIPTION
Small nit, DigitalOcean API keys contain lowercase letters only, no need for `xi`