### PR TITLE
add support for newer OpenAI API key formats

### DIFF
--- a/data/rules/openai.yml
+++ b/data/rules/openai.yml
@@ -35,7 +35,7 @@ rules:
       (?xi)
       \b
       (
-        (sk-(?:proj|svcacct|None)-[A-Z0-9_-]{100,}[A-Z0-9_-]*)
+        (sk-(?:proj|svcacct|None)-[A-Z0-9_-]{100,})
       )
       \b
     min_entropy: 4.0


### PR DESCRIPTION
OpenAI API keys can now take different forms:

- `sk-proj-***` - user generated at the project level
- `sk-svcacct-***` - tied to a service account
- `sk-None-***` - user generated within an org, but not tied to a project

The key length is not fixed, but seems to always be more than 100 chars.