### PR TITLE
v1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [1.34.0]
 - Use system TLS root certificates to support self-hosted GitLab instances with internal CAs
 - Added new rule: Coze personal access token
+- Updated Supabase rule to detect project url's and validate their corresponding tokens
 
 ## [1.33.0]
 - Fixed header precedence so custom HTTP validation headers like `Accept` are preserved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.34.0]
+- Use system TLS root certificates to support self-hosted GitLab instances with internal CAs
+- Added new rule: Coze personal access token
+
 ## [1.33.0]
 - Fixed header precedence so custom HTTP validation headers like `Accept` are preserved
 - Added new Heroku rule

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [package]
 name = "kingfisher"
-version = "1.33.0"
+version = "1.34.0"
 description = "MongoDB's blazingly fast secret scanning and validation tool"
 edition.workspace = true
 rust-version.workspace = true
@@ -82,9 +82,9 @@ reqwest = { version = "0.12", default-features = false, features = [
     "deflate", 
     "stream",
     "rustls-tls",
+    "rustls-tls-native-roots",
     "blocking",
     "multipart",
-    "rustls-tls",
 ] }
 
 

--- a/data/rules/aws.yml
+++ b/data/rules/aws.yml
@@ -6,7 +6,7 @@ rules:
       \b                  
       (
         (?:AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)
-        [0-9A-Z]{16}
+        [2-7A-Z]{16}
       )
       \b                  
     min_entropy: 3.2

--- a/data/rules/coze.yml
+++ b/data/rules/coze.yml
@@ -1,0 +1,31 @@
+rules:
+  - name: Coze Personal Access Token
+    id: kingfisher.coze.1
+    pattern: '(?i)\b(pat_[a-zA-Z0-9]{64})\b'
+    confidence: medium
+    min_entropy: 5.0
+    validation:
+      type: Http
+      content:
+        request:
+          method: GET
+          url: "https://api.coze.com/v1/workspaces?"
+          headers:
+            Authorization: "Bearer {{TOKEN}}"
+            Content-Type: application/json
+          response_matcher:
+            - type: StatusMatch
+              status: [200, 403] # API returns 403 for a valid token without permission to route
+            - type: JsonValid
+            - type: WordMatch
+              words:
+                - '"access token invalid"'
+                - '"does not have permission"'
+              negative: true
+    references:
+      - https://www.coze.com/docs/developer_guides/coze_api_overview
+      - https://www.coze.com/docs/developer_guides/retrieve_files
+    examples:
+      - "pat_DlOG7fNcVfmw8cYhPWNcdfwrjjzwDr9EkV8EBjzHdgRWU2DzqHC1pPe0x590NN5f"
+      - "pat_93QiTdIvZGuRCFcfGTQJJ1VIYZ9dNHanX88wKoMojwMk3tX5tKqfFtxUp0ux8CjI"
+      - "pat_WvUTLYq5yZyaqegkyLSxXJMjXAJotjYEuC1sqT8daFlfwM3BiaRVJIZsER42DnhV"

--- a/data/rules/supabase.yml
+++ b/data/rules/supabase.yml
@@ -1,5 +1,5 @@
 rules:
-  - name: Supabase API Key
+  - name: Supabase Management Token
     id: kingfisher.supabase.1
     pattern: |
       (?xi)
@@ -28,3 +28,53 @@ rules:
             - type: StatusMatch
               status:
                 - 200
+  - name: Supabase Project API Key
+    id: kingfisher.supabase.2
+    pattern: |
+      (?xi)
+      \b
+      (
+        sb_secret_[a-z0-9_-]{31}
+      )
+      \b
+    min_entropy: 4.0
+    confidence: high
+    validation:
+      type: Http
+      content:
+        request:
+          method: GET
+          url: "{{SBPROJECTURL}}/rest/v1/?select=*"
+          headers:
+            Apikey: "{{TOKEN}}"
+            User-Agent: ""
+          response_matcher:
+            - report_response: true
+            - type: StatusMatch
+              status: [200]
+            - type: WordMatch
+              words:
+                - '"host":'
+    references:
+      - https://supabase.com/docs/reference/api/v1-get-an-organization
+    examples:
+      - "sb_secret_9uM4GhB0STF5R4K3HxQtlg_bzWW6DRj"
+      - "sb_secret_szE_jsbktD3pWgnfUjgahw_hcHEIOBH"
+    depends_on_rule:
+      - rule_id: "kingfisher.supabase.3"
+        variable: SBPROJECTURL
+  - name: Supabase Project URL
+    id: kingfisher.supabase.3
+    pattern: 
+      (?xi)
+      (
+        https:\/\/[a-z0-9]{16,32}\.supabase\.co
+      )
+    confidence: medium
+    min_entropy: 3.0
+    visible: false
+    validation:
+    references:
+      - https://supabase.com/docs/guides/api
+    examples:
+      - "https://ejcvydfyxzmbtfbfstnq.supabase.co"


### PR DESCRIPTION
- Use system TLS root certificates to support self-hosted GitLab instances with internal CAs
- Added new rule: Coze personal access token