### PR TITLE
v1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.36.0]
 - Fixed GitHub organization and GitLab group scans when using `--git-history=none`
+- JWT tokens without both `iss` and `aud` are no longer reported as active credentials
 
 ## [1.35.0]
 - Remote scans with `--git-history=none` now clone repositories with a working tree and scan the current files instead of erroring with "No inputs to scan".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.36.0]
+- Fixed GitHub organization and GitLab group scans when using `--git-history=none`
+
 ## [1.35.0]
 - Remote scans with `--git-history=none` now clone repositories with a working tree and scan the current files instead of erroring with "No inputs to scan".
 - Fixed issue where `--redact` did not function properly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [package]
 name = "kingfisher"
-version = "1.35.0"
+version = "1.36.0"
 description = "MongoDB's blazingly fast secret scanning and validation tool"
 edition.workspace = true
 rust-version.workspace = true

--- a/data/rules/jira.yml
+++ b/data/rules/jira.yml
@@ -11,7 +11,7 @@ rules:
     visible: false
     confidence: medium
     examples:
-      - example-jira.atlassian.net
+      - examplefoo-jira.atlassian.net
       - jira.sprintUri= https://example.atlassian.net/rest
 
   - name: Jira Token

--- a/data/rules/onepassword.yml
+++ b/data/rules/onepassword.yml
@@ -44,7 +44,6 @@ rules:
       \b
     min_entropy: 3.8
     confidence: medium
-    prevalidated: true
     examples:
       - A3-R69SQK-TZ9KPW-8MXYD-6W373-V7GHJ-EDJQW
       - A3-ASWWYB-798JRY-LJVD4-23DC2-86TVM-H43EB

--- a/src/cli/commands/github.rs
+++ b/src/cli/commands/github.rs
@@ -60,7 +60,7 @@ pub struct GitHubRepoSpecifiers {
     pub all_organizations: bool,
 
     /// Filter by repository type
-    #[arg(long, default_value_t = GitHubRepoType::Source, alias = "github-repo-type")]
+    #[arg(long, default_value_t = GitHubRepoType::All, alias = "github-repo-type")]
     pub repo_type: GitHubRepoType,
 }
 

--- a/src/cli/commands/inputs.rs
+++ b/src/cli/commands/inputs.rs
@@ -60,7 +60,7 @@ pub struct InputSpecifierArgs {
     )]
     pub github_api_url: Url,
 
-    #[arg(long, default_value_t = GitHubRepoType::Source)]
+    #[arg(long, default_value_t = GitHubRepoType::All)]
     pub github_repo_type: GitHubRepoType,
 
     // GitLab Options
@@ -85,7 +85,7 @@ pub struct InputSpecifierArgs {
     )]
     pub gitlab_api_url: Url,
 
-    #[arg(long, default_value_t = GitLabRepoType::Owner)]
+    #[arg(long, default_value_t = GitLabRepoType::All)]
     pub gitlab_repo_type: GitLabRepoType,
 
     /// Jira base URL (e.g. https://jira.example.com)

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,13 +275,13 @@ fn create_default_scan_args() -> cli::commands::scan::ScanArgs {
             github_organization: Vec::new(),
             all_github_organizations: false,
             github_api_url: url::Url::parse("https://api.github.com/").unwrap(),
-            github_repo_type: GitHubRepoType::Source,
+            github_repo_type: GitHubRepoType::All,
             // new GitLab defaults
             gitlab_user: Vec::new(),
             gitlab_group: Vec::new(),
             all_gitlab_groups: false,
             gitlab_api_url: Url::parse("https://gitlab.com/").unwrap(),
-            gitlab_repo_type: GitLabRepoType::Owner,
+            gitlab_repo_type: GitLabRepoType::All,
 
             jira_url: None,
             jql: None,

--- a/src/reporter/json_format.rs
+++ b/src/reporter/json_format.rs
@@ -76,14 +76,14 @@ mod tests {
                 github_organization: Vec::new(),
                 all_github_organizations: false,
                 github_api_url: Url::parse("https://api.github.com/").unwrap(),
-                github_repo_type: GitHubRepoType::Source,
+                github_repo_type: GitHubRepoType::All,
 
                 // GitLab
                 gitlab_user: Vec::new(),
                 gitlab_group: Vec::new(),
                 all_gitlab_groups: false,
                 gitlab_api_url: Url::parse("https://gitlab.com/").unwrap(),
-                gitlab_repo_type: GitLabRepoType::Owner,
+                gitlab_repo_type: GitLabRepoType::All,
                 // Jira options
                 jira_url: None,
                 jql: None,

--- a/src/scanner/validation.rs
+++ b/src/scanner/validation.rs
@@ -335,12 +335,6 @@ pub async fn run_secret_validation(
         ds.replace_matches(updated_arcs);
     }
 
-    // ── 5. Done ─────────────────────────────────────────────────────────────
-    println!(
-        "Validation complete – {} succeeded, {} failed",
-        success_count.load(Ordering::Relaxed),
-        fail_count.load(Ordering::Relaxed)
-    );
     Ok(())
 }
 

--- a/src/validation/jwt.rs
+++ b/src/validation/jwt.rs
@@ -71,7 +71,11 @@ pub async fn validate_jwt(token: &str) -> Result<(bool, String)> {
 
     // ---------------------------------------------------------------------------
     let issuer = claims.iss.clone().unwrap_or_default();
+    let aud_strings = extract_aud_strings(&claims);
 
+    if issuer.trim().is_empty() && aud_strings.iter().all(|s| s.trim().is_empty()) {
+        return Ok((false, "JWT missing issuer and audience".to_string()));
+    }
     if let Some(iss) = claims.iss.clone() {
         // parse header now (kid, alg)
         let header = decode_header(token).map_err(|e| anyhow!("decode header: {e}"))?;

--- a/tests/int_rules_no_validated_findings.rs
+++ b/tests/int_rules_no_validated_findings.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use assert_cmd::Command;
+use serde_json::Value;
+
+#[test]
+fn scan_rules_has_no_validated_findings() -> Result<()> {
+    let output = Command::cargo_bin("kingfisher")?
+        .args([
+            "scan", "data/rules",
+            "--format", "json",
+            "--no-update-check",
+            "--only-valid",
+        ])
+        .output()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Find the first '[' — start of array
+    let start = match stdout.find('[') {
+        Some(i) => i,
+        None => return Ok(()), // no array found
+    };
+
+    let mut depth = 0usize;
+    let mut end = None;
+    for (i, ch) in stdout.char_indices().skip(start) {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let json_array_str = match end {
+        Some(end_idx) => &stdout[start..=end_idx],
+        None => return Ok(()), // no matching close found
+    };
+
+    if json_array_str.trim().is_empty() {
+        return Ok(());
+    }
+
+    let findings: Vec<Value> = serde_json::from_str(json_array_str)?;
+
+    for finding in findings {
+        let rule_id = finding["rule"]["id"].as_str().unwrap_or("unknown");
+        let rule_prevalidated = finding["rule"]["prevalidated"].as_bool().unwrap_or(false);
+
+        let status = finding["finding"]["validation"]["status"]
+            .as_str()
+            .unwrap_or("")
+            .to_ascii_lowercase();
+
+        let response = finding["finding"]["validation"]["response"]
+            .as_str()
+            .unwrap_or("")
+            .to_ascii_lowercase();
+
+        // Skip anything intentionally marked as prevalidated
+        if rule_prevalidated || status == "prevalidated" || response == "prevalidated" {
+            continue;
+        }
+
+        // Fail only on genuinely validated secrets
+        assert_ne!(
+            status.as_str(),
+            "active credential",
+            "Validated finding detected in rule {rule_id}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
- Fixed GitHub organization and GitLab group scans when using `--git-history=none`
- JWT tokens without both `iss` and `aud` are no longer reported as active credentials