### PR TITLE
v1.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.51.0]
+- Added diff-only Git scanning via `--since-commit` and `--branch`, including remote-aware ref resolution so CI jobs can pair `--git-url` clones with pull request branches
+
 ## [1.50.0]
 - Added `--github-exclude` and `--gitlab-exclude` options to skip specific repositories when scanning or listing GitHub and GitLab sources, including support for gitignore-style glob patterns
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [package]
 name = "kingfisher"
-version = "1.50.0"
+version = "1.51.0"
 description = "MongoDB's blazingly fast secret scanning and validation tool"
 edition.workspace = true
 rust-version.workspace = true

--- a/README.md
+++ b/README.md
@@ -349,9 +349,8 @@ The same diff-focused workflow works when cloning repositories on the fly with `
 ```bash
 kingfisher scan \
   --git-url https://github.com/org/repo.git \
-  --since-commit origin/main \
-  --branch origin/feature-1
-  --fail
+  --since-commit main \
+  --branch development
 ```
 
 In CI systems that expose the base and head commits explicitly, you can pass those SHAs directly while still using `--git-url`:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See ([docs/COMPARISON.md](docs/COMPARISON.md))
     - [Display rule performance statistics](#display-rule-performance-statistics)
     - [Scan while ignoring likely test files](#scan-while-ignoring-likely-test-files)
     - [Exclude specific paths](#exclude-specific-paths)
+    - [Scan changes in CI pipelines](#scan-changes-in-ci-pipelines)
   - [Scan an S3 bucket](#scan-an-s3-bucket)
   - [Scanning Docker Images](#scanning-docker-images)
   - [Scanning GitHub](#scanning-github)
@@ -329,6 +330,37 @@ kingfisher scan ./my-project \
 kingfisher scan ./my-project \
   --exclude '*.py' \
   --exclude '[Tt]ests'
+```
+
+### Scan changes in CI pipelines
+
+Limit scanning to the delta between your default branch and a pull request branch by combining `--since-commit` with `--branch` (defaults to `HEAD`). This only scans files that differ between the two references, which keeps CI runs fast while still blocking new secrets.
+
+```bash
+kingfisher scan . \
+  --since-commit origin/main \
+  --branch "$CI_BRANCH"
+```
+
+When the branch under test is already checked out, `--branch HEAD` or omitting `--branch` entirely is sufficient. Kingfisher exits with `200` when any findings are discovered and `205` when validated secrets are present, allowing CI jobs to fail automatically if new credentials slip in.
+
+The same diff-focused workflow works when cloning repositories on the fly with `--git-url`. Kingfisher automatically tries remote-tracking names like `origin/main` and `origin/feature-1`, so you can target the branches involved in a pull request without performing a local checkout first.
+
+```bash
+kingfisher scan \
+  --git-url https://github.com/org/repo.git \
+  --since-commit origin/main \
+  --branch origin/feature-1
+  --fail
+```
+
+In CI systems that expose the base and head commits explicitly, you can pass those SHAs directly while still using `--git-url`:
+
+```bash
+kingfisher scan \
+  --git-url git@github.com:org/repo.git \
+  --since-commit "$BASE_COMMIT" \
+  --branch "$PR_HEAD_COMMIT"
 ```
 
 If you want to know which files are being skipped, enable verbose debugging (-v) when scanning, which will report any files being skipped by the baseline file (or via --exclude):

--- a/src/cli/commands/inputs.rs
+++ b/src/cli/commands/inputs.rs
@@ -174,6 +174,14 @@ pub struct InputSpecifierArgs {
     /// Enable or disable scanning nested git repositories
     #[arg(long, default_value_t = true)]
     pub scan_nested_repos: bool,
+
+    /// Limit Git scanning to changes made since this commit or ref
+    #[arg(long = "since-commit", value_name = "GIT-REF", help_heading = "Git Options")]
+    pub since_commit: Option<String>,
+
+    /// Branch or ref containing changes to scan (defaults to HEAD)
+    #[arg(long, value_name = "GIT-REF", requires = "since_commit", help_heading = "Git Options")]
+    pub branch: Option<String>,
 }
 
 // -----------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,18 @@ use ignore::{DirEntry, WalkBuilder, WalkState};
 use tokio::time::Duration;
 use tracing::debug;
 
+#[derive(Clone)]
+pub struct GitDiffConfig {
+    pub since_ref: String,
+    pub branch_ref: Option<String>,
+}
+
 struct EnumeratorConfig {
     enumerate_git_history: bool,
     collect_git_metadata: bool,
     repo_scan_timeout: Duration,
     exclude_globset: Option<std::sync::Arc<GlobSet>>,
+    git_diff: Option<GitDiffConfig>,
 }
 
 pub enum FoundInput {

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,6 +320,8 @@ fn create_default_scan_args() -> cli::commands::scan::ScanArgs {
             commit_metadata: true,
             repo_artifacts: false,
             scan_nested_repos: true,
+            since_commit: None,
+            branch: None,
         },
         content_filtering_args: ContentFilteringArgs {
             max_file_size_mb: 25.0,

--- a/src/reporter/json_format.rs
+++ b/src/reporter/json_format.rs
@@ -112,6 +112,8 @@ mod tests {
                 commit_metadata: true,
                 repo_artifacts: false,
                 scan_nested_repos: true,
+                since_commit: None,
+                branch: None,
             },
             content_filtering_args: ContentFilteringArgs {
                 max_file_size_mb: 25.0,

--- a/tests/int_allowlist.rs
+++ b/tests/int_allowlist.rs
@@ -86,6 +86,8 @@ fn run_skiplist(skip_regex: Vec<String>, skip_skipword: Vec<String>) -> Result<u
             commit_metadata: true,
             repo_artifacts: false,
             scan_nested_repos: true,
+            since_commit: None,
+            branch: None,
         },
         content_filtering_args: ContentFilteringArgs {
             max_file_size_mb: 5.0,

--- a/tests/int_dedup.rs
+++ b/tests/int_dedup.rs
@@ -102,6 +102,8 @@ rules:
             commit_metadata: true,
             repo_artifacts: false,
             scan_nested_repos: true,
+            since_commit: None,
+            branch: None,
         },
         content_filtering_args: ContentFilteringArgs {
             max_file_size_mb: 5.0,

--- a/tests/int_github.rs
+++ b/tests/int_github.rs
@@ -89,6 +89,8 @@ fn test_github_remote_scan() -> Result<()> {
             commit_metadata: true,
             repo_artifacts: false,
             scan_nested_repos: true,
+            since_commit: None,
+            branch: None,
         },
         content_filtering_args: ContentFilteringArgs {
             max_file_size_mb: 25.0,

--- a/tests/int_gitlab.rs
+++ b/tests/int_gitlab.rs
@@ -87,6 +87,8 @@ fn test_gitlab_remote_scan() -> Result<()> {
             commit_metadata: true,
             repo_artifacts: false,
             scan_nested_repos: true,
+            since_commit: None,
+            branch: None,
         },
         content_filtering_args: ContentFilteringArgs {
             max_file_size_mb: 25.0,
@@ -197,6 +199,8 @@ fn test_gitlab_remote_scan_no_history() -> Result<()> {
             commit_metadata: true,
             repo_artifacts: false,
             scan_nested_repos: true,
+            since_commit: None,
+            branch: None,
         },
         content_filtering_args: ContentFilteringArgs {
             max_file_size_mb: 25.0,

--- a/tests/int_redact.rs
+++ b/tests/int_redact.rs
@@ -69,6 +69,8 @@ async fn test_redact_hashes_finding_values() -> Result<()> {
             commit_metadata: true,
             repo_artifacts: false,
             scan_nested_repos: true,
+            since_commit: None,
+            branch: None,
         },
         content_filtering_args: ContentFilteringArgs {
             max_file_size_mb: 25.0,

--- a/tests/int_slack.rs
+++ b/tests/int_slack.rs
@@ -75,6 +75,8 @@ impl TestContext {
                 commit_metadata: true,
                 repo_artifacts: false,
                 scan_nested_repos: true,
+                since_commit: None,
+                branch: None,
             },
             content_filtering_args: ContentFilteringArgs {
                 max_file_size_mb: 25.0,
@@ -175,6 +177,8 @@ async fn test_scan_slack_messages() -> Result<()> {
             commit_metadata: true,
             repo_artifacts: false,
             scan_nested_repos: true,
+            since_commit: None,
+            branch: None,
         },
         content_filtering_args: ContentFilteringArgs {
             max_file_size_mb: 25.0,

--- a/tests/int_validation_cache.rs
+++ b/tests/int_validation_cache.rs
@@ -145,6 +145,8 @@ async fn test_validation_cache_and_depvars() -> Result<()> {
             commit_metadata: true,
             repo_artifacts: false,
             scan_nested_repos: true,
+            since_commit: None,
+            branch: None,
         },
         content_filtering_args: ContentFilteringArgs {
             max_file_size_mb: 25.0,

--- a/tests/int_vulnerable_files.rs
+++ b/tests/int_vulnerable_files.rs
@@ -88,6 +88,8 @@ impl TestContext {
                 commit_metadata: true,
                 repo_artifacts: false,
                 scan_nested_repos: true,
+                since_commit: None,
+                branch: None,
             },
             content_filtering_args: ContentFilteringArgs {
                 max_file_size_mb: 25.0,
@@ -173,6 +175,8 @@ impl TestContext {
                 commit_metadata: true,
                 repo_artifacts: false,
                 scan_nested_repos: true,
+                since_commit: None,
+                branch: None,
             },
             content_filtering_args: ContentFilteringArgs {
                 max_file_size_mb: 25.0,


### PR DESCRIPTION
Added diff-only Git scanning via `--since-commit` and `--branch`, including remote-aware ref resolution so CI jobs can pair `--git-url` clones with pull request branches