### PR TITLE
v1.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [v1.54.0]
 - Added first-class Gitea support, including CLI commands, environment-based authentication, documentation, and integration with scans and repository enumeration.
 - Populate the finding path from git blob metadata so history-derived secrets display their file location instead of an empty path
+- Replaced Match::finding_id’s SHA1-based hashing with a fast xxh3_64 digest that keeps IDs deterministic while eliminating a hot-path SHA1 dependency
 
 ## [v1.53.0]
 - Added first-class Bitbucket support, including CLI commands, authentication helpers, documentation, and integration testing.

--- a/src/rules/rule.rs
+++ b/src/rules/rule.rs
@@ -17,7 +17,8 @@ use schemars::{
     JsonSchema,
 };
 use serde::{Deserialize, Serialize};
-use sha1::{Digest, Sha1};
+// use sha1::{Digest, Sha1};
+use xxhash_rust::xxh3::xxh3_64;
 
 /// Returns false as the default value.
 fn default_false() -> bool {
@@ -341,9 +342,8 @@ impl RuleSyntax {
 
     /// Computes a content-based fingerprint of the rule's pattern.
     pub fn finding_sha1_fingerprint(&self) -> String {
-        let mut hasher = Sha1::new();
-        hasher.update(self.pattern.as_bytes());
-        format!("{:x}", hasher.finalize())
+        let hash = xxh3_64(self.pattern.as_bytes());
+        format!("{:x}", hash)
     }
 
     /// Serializes the rule syntax to JSON.

--- a/src/update.rs
+++ b/src/update.rs
@@ -102,7 +102,7 @@ pub fn check_for_update(global_args: &GlobalArgs, base_url: Option<&str>) -> Opt
     // ───────────── Case 1: running == latest ─────────────
     if release.version == running_v {
         let plain = format!("Kingfisher {running_v} is up to date");
-        info!("{}", plain.as_str());
+        info!("{}", plain);
         return Some(plain);
     }
 


### PR DESCRIPTION
- Added first-class Gitea support, including CLI commands, environment-based authentication, documentation, and integration with scans and repository enumeration.
- Populate the finding path from git blob metadata so history-derived secrets display their file location instead of an empty path
- Replaced Match::finding_id’s SHA1-based hashing with a fast xxh3_64 digest that keeps IDs deterministic while eliminating a hot-path SHA1 dependency