### PR TITLE
Add JFrog Artifactory Reference Token rule.

### DIFF
--- a/data/rules/artifactory.yml
+++ b/data/rules/artifactory.yml
@@ -40,17 +40,17 @@ rules:
   - name: Artifactory JFrog URL
     id: kingfisher.artifactory.2
     pattern: |
-      (?xi)                       
-      \b                         
-      (                          
+      (?xi)
+      \b
+      (
         [a-z0-9]
         (?:
           [a-z0-9\-]{0,61}
           [a-z0-9]
         )?
         \.jfrog\.io
-      )                          
-      \b                         
+      )
+      \b
     min_entropy: 3.5
     visible: false
     confidence: medium
@@ -58,3 +58,37 @@ rules:
       - mycompany.jfrog.io
       - my-company-name.jfrog.io
       - a.jfrog.io
+
+  - name: Artifactory Identity Reference Token
+    id: kingfisher.artifactory.3
+    pattern: |
+      (?xi)
+      \b
+      (
+        cmVmd[A-Z0-9]{59}
+      )
+      \b
+    pattern_requirements:
+      min_digits: 2
+      min_uppercase: 1
+      min_lowercase: 1
+    min_entropy: 3.5
+    confidence: medium
+    examples:
+      - export HOMEBREW_ARTIFACTORY_API_REFERENCE_TOKEN=cmVmdawqkxT1EE4bMepW0zmTVmBYYdv264WVufgipR9CQAW2xwSnY4CTKap8H5u0
+    validation:
+      type: Http
+      content:
+        request:
+          headers:
+            Authorization: 'Bearer {{ TOKEN }}'
+          method: GET
+          response_matcher:
+            - report_response: true
+            - status:
+                - 200
+              type: StatusMatch
+          url: https://{{ JFROGURL }}/artifactory/api/repositories
+    depends_on_rule:
+      - rule_id: "kingfisher.artifactory.2"
+        variable: JFROGURL


### PR DESCRIPTION
JFrog Artifactory has been attempting to deprecate API keys in the past year. As of version 7.98.x it no longer supports creating new API keys. API keys have largely been replaced with reference and identity tokens. See more details about this [here](https://jfrog.com/help/r/jfrog-platform-administration-documentation/jfrog-api-key-deprecation-process).

This change adds a reference token detection rule with validation. 

The format for reference tokens is documented [here](https://jfrog.com/help/r/jfrog-platform-administration-documentation/understanding-identity-tokens).

## Validations
- [X] Validated detection and validation of active Reference Tokens
- [X] Validated detection and unsuccessful validation for expired Reference Tokens
