### PR TITLE
Add detection for short sk-None- prefixed OpenAI API keys

### DIFF
--- a/data/rules/openai.yml
+++ b/data/rules/openai.yml
@@ -60,3 +60,32 @@ rules:
                 - 200
               type: StatusMatch
           url: https://api.openai.com/v1/models
+
+  - name: OpenAI API Key (Short Prefixed)
+    id: kingfisher.openai.3
+    pattern: |
+      (?xi)
+      (
+        sk-None-[A-Z0-9]{48}
+      )
+    pattern_requirements:
+      min_digits: 2
+    min_entropy: 3.3
+    confidence: medium
+    examples:
+      - sk-None-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefgh
+    references:
+      - https://help.openai.com/en/articles/9132009-how-can-i-view-the-users-or-organizations-associated-with-an-api-key
+    validation:
+      type: Http
+      content:
+        request:
+          headers:
+            Authorization: 'Bearer {{ TOKEN }}'
+          method: GET
+          response_matcher:
+            - report_response: true
+            - status:
+                - 200
+              type: StatusMatch
+          url: https://api.openai.com/v1/me


### PR DESCRIPTION
## Summary
- Add new rule `kingfisher.openai.3` to detect short-form `sk-None-` prefixed OpenAI keys
- These keys have format: `sk-None-` + 48 alphanumeric characters (56 chars total)
- Existing rules only matched legacy keys (51 chars) or long prefixed keys (130+ chars)

## Test plan
- [x] Verified detection on test repo with a known `sk-None-` format key
- [x] Validation endpoint (`/v1/me`) confirms active credential detection
- [x] Existing OpenAI rules (`openai.1`, `openai.2`) remain unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)