### PR TITLE
fix(airtable): improve kingfisher.airtable.1 regex

### DIFF
--- a/data/rules/airtable.yml
+++ b/data/rules/airtable.yml
@@ -2,13 +2,13 @@ rules:
   - name: Airtable Personal Access Token
     id: kingfisher.airtable.1
     pattern: |
-      (?xi)                    
+      (?x)                    
       \b                       
       (                        
         pat
-        [a-z0-9]{14}
+        [A-Za-z0-9]{14}
         \.                     
-        [a-z0-9]{64}
+        [a-f0-9]{64}
       )
       \b
     pattern_requirements:


### PR DESCRIPTION
This regex can be tighter as the characters after the `.` are `a-f` only. Note: this is not documented publicly as far as I can tell