### PR TITLE
fix(alibaba): improve kingfisher.alibabacloud.1 regex

### DIFF
--- a/data/rules/alibaba.yml
+++ b/data/rules/alibaba.yml
@@ -4,7 +4,7 @@ rules:
     pattern: |
       (?x)
       (
-        LTAI([a-zA-Z0-9]{20}|[a-zA-Z0-9]{12})
+        LTAI([a-zA-Z0-9]{12,20})
       )
       \b
     pattern_requirements:


### PR DESCRIPTION
An Alibaba Access Key ID can be either 12 characters or 20 characters, ex: https://github.com/GuanceCloud/scheck/blob/2fca32ce9512ad73ba8e08649239d4eee9e3821b/dev.md?plain=1#L19

I can't quite figure out the right way to have the regex engine choose the longer pattern if it's present, so I updated it to be a range from 12 to 20.