### PR TITLE
fix(aws): improve kingfisher.aws.6 regex

### DIFF
--- a/data/rules/aws.yml
+++ b/data/rules/aws.yml
@@ -84,7 +84,7 @@ rules:
     pattern: |
       (?x)
       (
-        ABSKQmVkcm9ja0FQSUtleS[A-Za-z0-9+/]{91,}={0,2}
+        ABSKQmVkcm9ja0FQSUtleS[A-Za-z0-9+/]{91,121}={0,2}
       )
     min_entropy: 3.0
     confidence: medium


### PR DESCRIPTION
The regex for `AWS Bedrock API Key (Long-lived)` assumed a fixed length of 132 total characters, but this is not always the case, ex:
* 131: https://github.com/jinhua10/AI-Reviewer/blob/0b818fa17ec7df31ec1dde2db7ef9e86c26b191c/prompt-analysis.md?plain=1#L154
* 132: https://github.com/ecm-digital/ecmdigitalwebsite/blob/5bcf4fa48717ab117e693510f5b40789a3c65b15/public/index.html#L3262
* 133: https://github.com/JoseMose/Law-AI/blob/deddfbd7ff3b41cdbbdffb3c7c689c19a9b8bd6c/server/env-vars.json#L12

I've adjusted the pattern to specify a minimum length and an arbitrary upper bound 30 characters past that minimum. I also improved the matching on the `=` base64 padding characters.