### PR TITLE
feat(asana): add v2 tokens, split v1/v0 patterns

### DIFF
--- a/data/rules/asana.yml
+++ b/data/rules/asana.yml
@@ -121,6 +121,13 @@ rules:
           method: GET
           response_matcher:
             - report_response: true
+            - match_all_words: true
+              type: WordMatch
+              words:
+                - 'data:'
+                - email
+                - name
+          url: https://app.asana.com/api/1.0/users/me
 
   - name: Asana OAuth / Personal Access Token (V2)
     id: kingfisher.asana.5
@@ -160,13 +167,6 @@ rules:
           method: GET
           response_matcher:
             - report_response: true
-            - match_all_words: true
-              type: WordMatch
-              words:
-                - 'data:'
-                - email
-                - name
-          url: https://app.asana.com/api/1.0/users/me
             - match_all_words: true
               type: WordMatch
               words:


### PR DESCRIPTION
There is a v2 format of Asana API keys, ex: https://github.com/search?type=code&q=%2F2%5C%2F%5B0-9%5D%7B16%7D%5C%2F%5B0-9%5D%7B16%7D%3A%5Ba-f0-9%5D%7B32%7D%2F+AND+asana

Additionally, by splitting the v1 and v0 formats (called the "legacy" format in the GitHub docs for example) into separate patterns, we can improve the quality of the regex for those keys.