### PR TITLE
fix(circleci): improve kingfisher.circleci.1 regex

### DIFF
--- a/data/rules/circleci.yml
+++ b/data/rules/circleci.yml
@@ -16,10 +16,8 @@ rules:
     min_entropy: 3.5
     confidence: medium
     examples:
-      - CircleCI_PAT = "CCIPAT_lZyPAuThWn2G908ssDT0g33e_t7qh0r5hrvsqzmuraqzduq6qco5onxgrtcn7y2z4"
-      - CCIPAT_FERZRjTN451xnDCy1y9gWn_79fb6ca4d0e5f833612eee17de397a9dca0a9e9f
       - |
-        export CIRCLECI_TOKEN=CCIPAT_lZyPAuThWn2G908ssDT0g33e_t7qh0r5hrvsqzmuraqzduq6qco5onxgrtcn7y2z4
+        export CIRCLECI_TOKEN=CCIPAT_FERZRjTN451xnDCy1y9gWn_79fb6ca4d0e5f833612eee17de397a9dca0a9e9f
     references:
       - https://circleci.com/docs/api-developers-guide/#using-the-api-securely-wtih-curl
     validation:


### PR DESCRIPTION
The regex for CircleCI seems far too specific, for example I found this example PAT which has a number (`4`) as the 9th character after `CCIPAT_` when the pattern currently only allows `[a-z]` in that position: https://github.com/fosti2115/GitGuardian/blob/9879fb107d0307720abd61560ee084087e389fd7/GitGuardian/CircleCI%20Personal%20Token#L2

Unless there's a particular location where this was documented by CircleCI (I can't find one), it would be safer to allow `[a-zA-Z0-9]` for all 22 characters.

Additionally, I can't find a single example outside of the kingfisher codebase that matches the current pattern of 24 characters, I believe it's incorrect: https://github.com/search?type=code&q=%2FCCIPAT_%5Ba-zA-Z0-9%5D%7B24%7D_%2F