### PR TITLE
fix(deepseek): improve kingfisher.deepseek.1 regex

### DIFF
--- a/data/rules/deepseek.yml
+++ b/data/rules/deepseek.yml
@@ -2,7 +2,7 @@ rules:
   - name: DeepSeek API Key
     id:   kingfisher.deepseek.1
     pattern: |
-      (?xi)
+      (?x)
       \b
       (
         sk-[a-f0-9]{32}


### PR DESCRIPTION
All DeepSeek keys are lowercase hex characters, we can remove the case-insensitive flag on the pattern.