### PR TITLE
fix(discord): improve kingfisher.discord.1 regex

### DIFF
--- a/data/rules/discord.yml
+++ b/data/rules/discord.yml
@@ -4,11 +4,11 @@ rules:
     pattern: |
       (?xi)
       (
-        https://discord\.com/api/webhooks/
-        \d{18}
+        https://discord(app)?\.com/api/webhooks/
+        [0-9]{17,20}
       )/
       (
-        [0-9a-z_\-]{68}
+        [0-9a-z_\-]{60,68}
       )
       \b
     pattern_requirements:


### PR DESCRIPTION
The domain for Discord webhooks can be either `discord.com` or `discordapp.com`.

Additionally, the first number segment can be lengths other than 18, ex:
* 17: https://github.com/ninthwalker/AHNotifier/blob/0e449807e71fbdd5492412937c455e1ff41dfda0/settings.sample#L29
* 18: https://github.com/DJPlaya/Cheat-Acid/blob/4739c13885227930162729018ffcf14f70e4b8ac/GRAB/AntiCheat-PF/AC-Main.sp#L182
* 19: https://github.com/rifainareswara/rnrifai/blob/09c372b86bfa26401aead6f50d9cba248fc205f7/Jenkinsfile1#L59
* 20: https://github.com/markekraus/TwitchDiscordNotificationBot/blob/3824947b5c84a2c30a5576a9bf7794948cac1cee/README.md?plain=1#L74

Finally the last segment seems to be variable length other than 60 as well.