### PR TITLE
feat(dockerhub): add Organization Access Token regex (kingfisher.dockerhub.2), improve PAT regex (kingfisher.dockerhub.1)

### DIFF
--- a/data/rules/dockerhub.yml
+++ b/data/rules/dockerhub.yml
@@ -2,12 +2,12 @@ rules:
   - name: Docker Hub Personal Access Token
     id: kingfisher.dockerhub.1
     pattern: |
-      (?xi)
+      (?x)
       \b
       (
-        dckr_pat_[A-Z0-9_-]{27}
+        dckr_pat_[A-Za-z0-9_-]{27}
       )
-      (?: $ | [^A-Z0-9_-] )
+      (?: $ | [^A-Za-z0-9_-] )
     pattern_requirements:
       min_digits: 2
     min_entropy: 3.3
@@ -18,6 +18,37 @@ rules:
       - docker login -u gemesa -p dckr_pat_1q8yKET1VDJTpfCwseUDzT8vFh-
     references:
       - https://docs.docker.com/reference/api/hub/latest/#tag/access-tokens/paths/~1v2~1access-tokens~1%7Buuid%7D/get
+    validation:
+      type: Http
+      content:
+        request:
+          headers:
+            Authorization: Bearer {{ TOKEN }}
+            Accept: application/json
+          method: GET
+          response_matcher:
+            - report_response: true
+            - status:
+                - 200
+              type: StatusMatch
+          url: https://hub.docker.com/v2/access-tokens?page_size=1
+  - name: Docker Hub Organization Access Token
+    id: kingfisher.dockerhub.2
+    pattern: |
+      (?x)
+      \b
+      (
+        dckr_oat_[A-Za-z0-9_-]{32}
+      )
+      (?: $ | [^A-Za-z0-9_-] )
+    pattern_requirements:
+      min_digits: 2
+    min_entropy: 3.3
+    confidence: medium
+    examples:
+      - docker login -u docker-test -p dckr_oat_7bA9zRt5-JqX3vP0l_MnY8sK2wE-dF6h
+    references:
+      - https://docs.docker.com/enterprise/security/access-tokens/
     validation:
       type: Http
       content:


### PR DESCRIPTION
Adds a new pattern for DockerHub OATs: https://docs.docker.com/enterprise/security/access-tokens/

The validation for this won't actually work due to #202