### PR TITLE
feat(neon): add Neon API Key rule

### DIFF
--- a/data/rules/neon.yml
+++ b/data/rules/neon.yml
@@ -1,0 +1,31 @@
+rules:
+  - name: Neon API Key
+    id: kingfisher.neon.1
+    pattern: |
+      (?x)
+      \b
+      (
+        napi_
+        [a-zA-Z0-9]{64}
+      )
+      \b
+    min_entropy: 3.5
+    confidence: high
+    examples:
+      - napi_f6n4wv0d0nzglfk64c1bnzrc5ug82tmrmekh8h4hsxeq8zd0p5ii234bdkah71kw
+    references:
+      - https://neon.com/docs/manage/api-keys
+    validation:
+      type: Http
+      content:
+        request:
+          headers:
+            Authorization: Bearer {{ TOKEN }}
+            Accept: application/json
+          method: GET
+          response_matcher:
+            - report_response: true
+            - status:
+                - 200
+              type: StatusMatch
+          url: https://console.neon.tech/api/v2/auth


### PR DESCRIPTION
Add validation for Neon API keys: https://neon.com/docs/manage/api-keys

It would be great to add connection strings too but that will require finding the right HTTP API that can be polled (I'm sure one exists)