### PR TITLE
fix(planetscale): improve kingfisher.planetscale.1 regex

### DIFF
--- a/data/rules/planetscale.yml
+++ b/data/rules/planetscale.yml
@@ -5,7 +5,7 @@ rules:
       (?xi)
       \b
       (
-        pscale_tkn_[a-z0-9-_]{43}
+        pscale_tkn_[a-z0-9-_]{32,64}
       )
       \b
     pattern_requirements:


### PR DESCRIPTION
These tokens are not consistently 43 characters in length, ex: https://github.com/search?type=code&q=%2Fpscale_tkn_%5Ba-zA-Z0-9_-%5D%7B32%2C42%7D%2F

There seem to be some shorter, I didn't find any longer but I figure the prefix is unique enough it would be safer to extend the length limit instead.