### PR TITLE
fix(age): reduce allowed characters to bech32 alphabet

### DIFF
--- a/data/rules/age.yml
+++ b/data/rules/age.yml
@@ -2,14 +2,13 @@ rules:
   - name: Age Recipient (X25519 public key)
     id: kingfisher.age.1
     pattern: |
-      (?xi)
+      (?x)
       (
-        age1[0-9a-z]{58}
+        age1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{58}
       )
       \b
     pattern_requirements:
       min_digits: 2
-      min_uppercase: 1
       min_lowercase: 1
     min_entropy: 3.3
     confidence: medium
@@ -23,9 +22,9 @@ rules:
   - name: Age Identity (X22519 secret key)
     id: kingfisher.age.2
     pattern: |
-      (?xi)
+      (?x)
       (
-        AGE-SECRET-KEY-1[0-9A-Z]{58}
+        AGE-SECRET-KEY-1[QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L]{58}
       )
     min_entropy: 3.3
     confidence: medium


### PR DESCRIPTION
age uses [bech32](https://en.bitcoin.it/wiki/Bech32) to encode the public/private key into alphanumeric characters, we can improve the matching by using only that character set: https://github.com/FiloSottile/age/blob/10561a774f9f6de47c8d23ddc58537b6a18b083d/internal/bech32/bech32.go#L30

Additionally, I removed the `(?i)` mode and the `min_uppercase` constraint from `kingfisher.age.1` as it will never match a valid public key as they are lowercase characters only. @mickgmdb should the CI based checks against `examples` also include validation that `pattern_requirements` are valid/met to catch this in the future?