### PR TITLE
feat(age): add rules for post-quantum keys (MLKEM768-X25519)

### DIFF
--- a/data/rules/age.yml
+++ b/data/rules/age.yml
@@ -44,7 +44,7 @@ rules:
   - name: Age Recipient (MLKEM768-X25519 public key)
     id: kingfisher.age.3
     pattern: |
-      (?xi)
+      (?x)
       \b
       (
         age1pq1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{1952}


### PR DESCRIPTION
age has a new post-quantum key format (MLKEM768-X25519): https://github.com/C2SP/C2SP/blob/8b6a842e0360d35111c46be2a8019b2276295914/age.md#the-x25519-recipient-type

```
$ age-keygen --help
Usage:
    age-keygen [-pq] [-o OUTPUT]
    age-keygen -y [-o OUTPUT] [INPUT]

...

age-keygen generates a new native X25519 or, with the -pq flag, post-quantum
hybrid ML-KEM-768 + X25519 key pair, and outputs it to standard output or to
the OUTPUT file.

...

Examples:
    $ age-keygen -pq
    # created: 2025-11-17T12:15:17+01:00
    # public key: age1pq1pd[... 1950 more characters ...]
    AGE-SECRET-KEY-PQ-1XXC4XS9DXHZ6TREKQTT3XECY8VNNU7GJ83C3Y49D0GZ3ZUME4JWS6QC3EF
```
This PR adds rules for these keys as well