### PR TITLE
fix(aws): improve kingfisher.aws.1 regex

### DIFF
--- a/data/rules/aws.yml
+++ b/data/rules/aws.yml
@@ -2,7 +2,7 @@ rules:
   - name: AWS Access Key ID
     id: kingfisher.aws.1
     pattern: |
-      (?xi)             
+      (?x)             
       \b
       (
         (?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)


### PR DESCRIPTION
This doesn't need to be case insensitive, it's always uppercase