### PR TITLE
[codex] Bump jsonwebtoken to 10.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ percent-encoding = "2.3.2"
 self_update = { version = "0.43.1", default-features = false, features = ["reqwest", "rustls", "archive-tar", "archive-zip", "compression-flate2"] }
 semver = "1.0.27"
 globset = "0.4.18"
-jsonwebtoken = { version = "10.2.0", features = ["aws-lc-rs"] }
+jsonwebtoken = { version = "10.3.0", features = ["aws-lc-rs"] }
 ipnet = "2.11.0"
 gouqi = { version = "0.20.0", features = ["async"] }
 oci-client = { version = "0.16", default-features = false, features = ["rustls-tls"] }

--- a/crates/kingfisher-scanner/Cargo.toml
+++ b/crates/kingfisher-scanner/Cargo.toml
@@ -165,7 +165,7 @@ pem = { version = "3.0.6", optional = true }
 percent-encoding = { workspace = true, optional = true }
 ring = { version = "0.17", optional = true }
 
-jsonwebtoken = { version = "10.2.0", features = ["aws-lc-rs"], optional = true }
+jsonwebtoken = { version = "10.3.0", features = ["aws-lc-rs"], optional = true }
 p256 = { version = "0.13.2", optional = true }
 ed25519-dalek = { version = "2.2", features = ["pkcs8"], optional = true }
 hex = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
- bump the direct `jsonwebtoken` manifest requirement from `10.2.0` to `10.3.0` in the workspace root and `kingfisher-scanner`
- leave `Cargo.lock` unchanged because `main` already resolves `jsonwebtoken 10.3.0`

## Why
GitHub Dependabot is reporting an open security alert for `jsonwebtoken` (`GHSA-h395-gr6q-cpjc`, `CVE-2026-25537`). The default branch already contains the patched lockfile entry, but both manifests still advertise the vulnerable `10.2.0` requirement, so the alert remains open.

## Impact
This makes the patched minimum version explicit in both manifests and aligns the declared dependency constraint with the version already locked on `main`.

## Validation
- `CARGO_TARGET_DIR=/tmp/kingfisher-codex-check cargo check -p kingfisher-scanner --features validation-jwt`
- `CARGO_TARGET_DIR=/tmp/kingfisher-codex-check cargo test --test cli_validate_revoke validate::validate_jwt_token -- --exact`
