### PR TITLE
Fix documentation site deployment

### DIFF
--- a/docs-site/docs/usage/configuration.md
+++ b/docs-site/docs/usage/configuration.md
@@ -272,5 +272,5 @@ alerts:
       format: slack
 ```
 
-Combined with [`docs/ALERTS.md`](ALERTS.md), this lets one repo own its
+Combined with [`docs/ALERTS.md`](https://github.com/mongodb/kingfisher/blob/main/docs/ALERTS.md), this lets one repo own its
 webhook configuration and CI policy without baking it into command-line strings.


### PR DESCRIPTION
This pull request makes a small documentation update to the `docs-site/docs/usage/configuration.md` file. The change updates a relative link to `ALERTS.md` to use an absolute GitHub URL, improving clarity and reducing confusion for readers.