### PR TITLE
Fix CI job failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ env:
   VCPKG_DOWNLOADS: C:\vcpkg\downloads
   VCPKG_FEATURE_FLAGS: binarycaching
   VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
   RUST_TOOLCHAIN: "1.96.0"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ env:
   VCPKG_DOWNLOADS: C:\vcpkg\downloads
   VCPKG_FEATURE_FLAGS: binarycaching
   VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
   RUST_TOOLCHAIN: "1.96.0"
 
 jobs:
@@ -63,11 +66,17 @@ jobs:
         run: make tests
         env:
           CARGO_BUILD_JOBS: 1
+
+      - name: Reclaim test artifacts
+        run: |
+          rm -rf target/debug
+          df -h
+
       - name: Build (Makefile linux-x64)
         run: make ubuntu-x64
 
       - name: Fix permissions
-        run: sudo chown -R $(id -u):$(id -g) target
+        run: sudo chown -R "$(id -u):$(id -g)" target
 
       - name: Build Debian package
         run: |
@@ -138,11 +147,17 @@ jobs:
         run: make tests
         env:
           CARGO_BUILD_JOBS: 1
+
+      - name: Reclaim test artifacts
+        run: |
+          rm -rf target/debug
+          df -h
+
       - name: Build (Makefile linux-arm64)
         run: make ubuntu-arm64
 
       - name: Fix permissions
-        run: sudo chown -R $(id -u):$(id -g) target
+        run: sudo chown -R "$(id -u):$(id -g)" target
 
       - name: Build Debian package
         run: |


### PR DESCRIPTION
This pull request updates the CI and release GitHub Actions workflows to optimize Rust build and test performance, and to better manage disk space during builds. The most important changes are grouped below.

**Rust build optimization:**

* Disabled incremental compilation and debug info for dev and test profiles by setting `CARGO_INCREMENTAL`, `CARGO_PROFILE_DEV_DEBUG`, and `CARGO_PROFILE_TEST_DEBUG` to `"0"` in both `.github/workflows/ci.yml` and `.github/workflows/release.yml` environments. This reduces build times and disk usage for CI runs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR16-R18) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R24-R26)

**Disk space management:**

* Added a step in the release workflow to remove the `target/debug` directory after running tests and before building release artifacts, helping to reclaim disk space and avoid storage issues. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R69-R79) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R150-R160)

**Workflow maintenance:**

* Fixed the `chown` command in the release workflow by quoting the user and group substitution, improving reliability in permission fixing steps. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R69-R79) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R150-R160)