### PR TITLE
fix(rules): correct Dynatrace token regex and validate against tenant

### DIFF
--- a/crates/kingfisher-rules/data/rules/dynatrace.yml
+++ b/crates/kingfisher-rules/data/rules/dynatrace.yml
@@ -5,31 +5,68 @@ rules:
       (?x)
       \b
       (
-        dt0[a-zA-Z][0-9]{2}
+        dt0[a-z][0-9]{2}        # token type prefix (e.g. dt0c01, dt0s16)
         \.
-        [A-Za-z0-9]{24}
+        [a-zA-Z0-9-]{8,128}     # public, non-secret token identifier
         \.
-        [A-Za-z0-9]{64}
+        [A-Z0-9]{64}            # the actual secret
       )
       \b
     pattern_requirements:
       min_digits: 2
     min_entropy: 3.3
-    confidence: medium
+    confidence: high
     examples:
       - dt0c01.ST2EY72KQINMH574WMNVI7YN.G3DFPBEJYMODIDAEX454M7YWBUVEFOWKPRVMWFASS64NFH52PX6BNDVFFM572RZM
+      - dt0s02.UZCK6ENL.2YQ2A3DZUEISRJSUU5544J3SC3TMPXSEEMNA5HK7RW54SJ6XKLYGMWJNKL7B2DNH
     references:
-      - https://docs.dynatrace.com/docs/discover-dynatrace/references/dynatrace-api/basics/dynatrace-api-authentication
+      - https://docs.dynatrace.com/docs/dynatrace-api/basics/dynatrace-api-authentication
+    # token is tenant-scoped; validate against the nearest tenant host (helper rule below)
+    depends_on_rule:
+      - rule_id: "kingfisher.dynatrace.2"
+        variable: DT_TENANT
     validation:
       type: Http
       content:
         request:
-          method: GET
-          url: https://api.dynatrace.com/v2/release-notes
+          method: POST
+          # apps UI hosts have no API -> rewrite to the API host
+          url: 'https://{{ DT_TENANT | downcase | replace: ".apps.dynatrace.com", ".live.dynatrace.com" | replace: ".apps.", "." }}/api/v2/apiTokens/lookup'
           headers:
             Authorization: "Api-Token {{ TOKEN }}"
+            Accept: "application/json; charset=utf-8"
+            Content-Type: "application/json; charset=utf-8"
+          body: '{"token":"{{ TOKEN }}"}'
           response_matcher:
             - report_response: true
+            # 200 = valid; 403 = valid but missing apiTokens.read scope; 401 = invalid
             - type: StatusMatch
-              status: [200]
+              status: [200, 403]
             - type: JsonValid
+
+  # helper: captures the SaaS tenant host near a token, used to scope token validation
+  - name: Dynatrace Tenant
+    id: kingfisher.dynatrace.2
+    pattern: |
+      (?xi)
+      \b
+      (
+        [a-z0-9-]+
+        \.
+        (?:
+          live\.dynatrace
+          | apps\.dynatrace
+          | (?:dev|sprint)\.dynatracelabs
+          | (?:dev|sprint)\.apps\.dynatracelabs
+        )
+        \.com
+      )
+      \b
+    min_entropy: 2.0
+    confidence: high
+    visible: false
+    examples:
+      - wkf10640.live.dynatrace.com
+      - asd12345.sprint.apps.dynatracelabs.com
+    references:
+      - https://docs.dynatrace.com/docs/dynatrace-api/basics/dynatrace-api-authentication


### PR DESCRIPTION
## Summary

The existing `kingfisher.dynatrace.1` rule had an incorrect detection regex and a non-functional validation. This PR corrects both and adds active verification that authenticates each token against its Dynatrace tenant.

## What was wrong

**Regex** matched a narrower/incorrect token shape than real Dynatrace tokens:

| Segment | Before | Correct |
|---|---|---|
| type prefix | `dt0[a-zA-Z][0-9]{2}` | `dt0[a-z][0-9]{2}` |
| public identifier | `[A-Za-z0-9]{24}` (fixed 24, no `-`) | `[a-zA-Z0-9-]{8,128}` |
| secret | `[A-Za-z0-9]{64}` | `[A-Z0-9]{64}` (uppercase + digits) |

**Validation** sent a request to `https://api.dynatrace.com/v2/release-notes`. This endpoint doesn't exist, and since `dt0…` tokens are scoped (based on the prefix), they cannot be verified against `api.dynatrace.com`. Validation could therefore never succeed.

## What this changes

- **Corrected token regex** `dt0[a-z][0-9]{2}\.[a-zA-Z0-9-]{8,128}\.[A-Z0-9]{64}`, confidence raised to `high` (strongly self-identifying prefix + 64-char secret).
- **Tenant-scoped validation.** A token can only be verified against its tenant, and the tenant host is not part of the token. A new hidden helper rule `kingfisher.dynatrace.2` captures the Dynatrace SaaS tenant host near the token; the token rule `depends_on_rule` it and authenticates via `POST https://{tenant}/api/v2/apiTokens/lookup`.
- **UI-host normalization.** The validation URL rewrites 3rd-gen references to the API host via filters: `…apps.dynatrace.com → …live.dynatrace.com` and `…dev/sprint.apps.… → …dev/sprint.…`. The captured (original) host is preserved in output; only the outgoing request is rewritten.
- **Status mapping:** `200` → valid, `403` (valid token lacking the `apiTokens.read` scope) → valid, `401` → invalid. Implemented with `StatusMatch: [200, 403]`.

## Behavior & limitations

- Detection is independent of validation: if no tenant host is found near the token, the token is **still reported**, with validation status **"Not Attempted"** as there is nothing to verify against.
- Tenant pairing is by proximity: each token uses the single **nearest preceding** tenant in the same file (falling back to nearest following). It is **one tenant per token**, not a cartesian product, and there is no retry against other tenants on a `401`.
- Only **SaaS** tenants are auto-discovered (`live`/`apps`/`dev`/`sprint` shapes). Dynatrace **Managed** (`{domain}/e/{env-id}`) tokens are reported but not auto-validated.
- The validated tenant is surfaced in the finding's `validate_command` (`--var DT_TENANT=…`) in both pretty and JSON output; there is no dedicated tenant field.
- The hidden tenant helper rule is set to `confidence: high` to match the token rule, so a `--confidence high` scan does not filter out the helper and silently break validation (a helper must be at least as confident as the rule that depends on it).

## Testing

- `kingfisher rules check` passes; detection confirmed against both examples.
- Verified live against real tenants (results not committed):
  - valid token + correct tenant → **Active Credential** (200, returns token metadata)
  - valid token lacking lookup scope → **Active Credential** (403)
  - `apps` UI host → rewritten to the API host and validates (confirmed the `apps` host returns 404 for the lookup API directly, while the rewritten request returns the API's real status)
  - invalid secret → **Inactive Credential** (401)
  - token with no tenant in the file → reported, **Not Attempted**
  - file with multiple tokens + tenants → each token paired with its nearest tenant (no cross/cartesian validation)
  - `--confidence high` scan → validation still works (helper rule is also `high`)