### PR TITLE
feat: detect secrets in ZIP archives that lack a recognized extension (e.g. Terraform tf.plan)

### DIFF
--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -382,6 +382,27 @@ fn handle_zip_archive_streaming(
     Ok(CompressedContent::ArchiveFiles(entries_on_disk))
 }
 
+/// Extract in-memory ZIP `buffer` via the disk-streaming extractor.
+///
+/// Used for content-sniffed ZIPs that exceed `MAX_INMEM_ZIP_ARCHIVE_BYTES`, so
+/// they take the streaming path (no total-input cap) rather than the in-memory
+/// extractor. `label_path` is used only to label entries (`label_path!entry`),
+/// keeping report paths consistent with the in-memory branch. Entries are
+/// written under `base_dir`.
+fn extract_zip_bytes_via_streaming(
+    buffer: &[u8],
+    label_path: &Path,
+    base_dir: &Path,
+) -> Result<CompressedContent> {
+    let staged = base_dir.join(format!("{}.zip", Uuid::new_v4()));
+    let mut out = safe_create_for_write(&staged)?;
+    out.write_all(buffer)?;
+    drop(out);
+
+    let mut file = safe_open_for_read(&staged)?;
+    handle_zip_archive_streaming(&mut file, label_path, base_dir)
+}
+
 /// Extract streams from an HWP (Hancom Word Processor) file.
 ///
 /// HWP 5.x uses the Microsoft Compound File Binary (OLE2/CFBF) container.
@@ -682,17 +703,39 @@ fn decompress_once_with_single_stream_cap(
 
     if looks_like_zip(&buffer) {
         let archive_label = path.display().to_string();
-        match extract_zip_archive_in_memory(&buffer, &archive_label) {
-            // Only treat it as an archive if it yielded entries; an empty or
-            // unreadable result falls through to scanning the raw bytes.
-            Ok(entries) if !entries.is_empty() => {
-                return Ok(CompressedContent::Archive(entries));
+        if buffer.len() <= MAX_INMEM_ZIP_ARCHIVE_BYTES {
+            match extract_zip_archive_in_memory(&buffer, &archive_label) {
+                // Only treat it as an archive if it yielded entries; an empty or
+                // unreadable result falls through to scanning the raw bytes.
+                Ok(entries) if !entries.is_empty() => {
+                    return Ok(CompressedContent::Archive(entries));
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::debug!(
+                        "content-sniffed zip extract failed for {archive_label}: {e:#}; scanning raw bytes"
+                    );
+                }
             }
-            Ok(_) => {}
-            Err(e) => {
-                tracing::debug!(
-                    "content-sniffed zip extract failed for {archive_label}: {e:#}; scanning raw bytes"
-                );
+        } else {
+            // Larger than the in-memory cap: stage the bytes and use the
+            // streaming extractor (no total-input cap) instead of dropping to a
+            // raw scan of the compressed bytes.
+            let owned_temp;
+            let base = match base_dir {
+                Some(b) => b,
+                None => {
+                    owned_temp = tempdir()?;
+                    owned_temp.path()
+                }
+            };
+            match extract_zip_bytes_via_streaming(&buffer, path, base) {
+                Ok(content) => return Ok(content),
+                Err(e) => {
+                    tracing::debug!(
+                        "content-sniffed streaming zip extract failed for {archive_label}: {e:#}; scanning raw bytes"
+                    );
+                }
             }
         }
     }
@@ -872,6 +915,40 @@ mod tests {
         match decompress_once(&plan, Some(dir.path()))? {
             CompressedContent::Raw(raw) => assert_eq!(raw, bytes),
             other => panic!("expected Raw for empty zip, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    /// The streaming route for large content-sniffed ZIPs (exercised here with a
+    /// small ZIP to avoid a >64 MB fixture) must extract entries to disk and
+    /// label them `label_path!entry`, matching the in-memory branch.
+    #[test]
+    fn streaming_zip_bytes_extracts_and_labels_by_path() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let github_pat = "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"; // this is not a real secret
+
+        let mut bytes = Vec::new();
+        {
+            let mut zip = ZipWriter::new(std::io::Cursor::new(&mut bytes));
+            let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+            zip.start_file("tfstate", opts)?;
+            zip.write_all(format!("token={github_pat}\n").as_bytes())?;
+            zip.finish()?;
+        }
+
+        // The label path is logical only; it need not exist on disk.
+        let label = Path::new("tf.plan");
+        match super::extract_zip_bytes_via_streaming(&bytes, label, dir.path())? {
+            CompressedContent::ArchiveFiles(entries) => {
+                let (_, on_disk) = entries
+                    .iter()
+                    .find(|(logical, _)| logical == "tf.plan!tfstate")
+                    .expect("expected tf.plan!tfstate entry");
+                let txt = std::fs::read_to_string(on_disk)?;
+                assert!(txt.contains(github_pat));
+            }
+            other => panic!("expected ArchiveFiles from streaming extract, got {other:?}"),
         }
 
         Ok(())

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -290,9 +290,10 @@ pub fn extract_zip_archive_in_memory(
     Ok(entries)
 }
 
-/// Return true if `data` begins with a standard ZIP signature — used to
-/// short-circuit extraction attempts on blobs whose extension matches a
-/// ZIP-based format but whose contents are not actually a real ZIP.
+/// Return true if `data` begins with a standard ZIP signature. Used both to
+/// short-circuit extraction of blobs whose extension matches a ZIP-based format
+/// but whose contents are not a real ZIP, and to detect ZIP containers that
+/// carry no recognized archive extension (e.g. a Terraform `tf.plan`).
 pub fn looks_like_zip(data: &[u8]) -> bool {
     data.starts_with(b"PK\x03\x04")
         || data.starts_with(b"PK\x05\x06")
@@ -673,9 +674,29 @@ fn decompress_once_with_single_stream_cap(
         }
     }
 
-    // Unknown extension -- just read the bytes
+    // Unknown extension: read the bytes, then content-sniff. A file whose name
+    // carries no archive extension may still be a ZIP (e.g. a `tfplan`). The
+    // already-read buffer feeds the bounded in-memory extractor directly.
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer)?;
+
+    if looks_like_zip(&buffer) {
+        let archive_label = path.display().to_string();
+        match extract_zip_archive_in_memory(&buffer, &archive_label) {
+            // Only treat it as an archive if it yielded entries; an empty or
+            // unreadable result falls through to scanning the raw bytes.
+            Ok(entries) if !entries.is_empty() => {
+                return Ok(CompressedContent::Archive(entries));
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::debug!(
+                    "content-sniffed zip extract failed for {archive_label}: {e:#}; scanning raw bytes"
+                );
+            }
+        }
+    }
+
     Ok(CompressedContent::Raw(buffer))
 }
 
@@ -783,6 +804,77 @@ mod tests {
             base_dir,
             super::MAX_SINGLE_STREAM_DECOMPRESSED_BYTES,
         )
+    }
+
+    /// A ZIP body written under a name with no recognized archive extension
+    /// (mirroring a Terraform `tf.plan`) must still be extracted via content
+    /// sniffing rather than scanned as opaque bytes.
+    #[test]
+    fn decompress_sniffs_zip_without_archive_extension() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let plan = dir.path().join("tf.plan");
+        let github_pat = "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"; // this is not a real secret
+
+        {
+            let f = File::create(&plan)?;
+            let mut zip = ZipWriter::new(f);
+            let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+            zip.start_file("tfstate", opts)?;
+            zip.write_all(format!("token={github_pat}\n").as_bytes())?;
+            zip.finish()?;
+        }
+
+        match decompress_once(&plan, Some(dir.path()))? {
+            CompressedContent::Archive(entries) => {
+                let found = entries.iter().any(|(logical, bytes)| {
+                    logical.ends_with("!tfstate")
+                        && std::str::from_utf8(bytes).is_ok_and(|s| s.contains(github_pat))
+                });
+                assert!(found, "expected tfstate entry with secret, got {entries:?}");
+            }
+            other => panic!("expected Archive from content-sniffed zip, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    /// A non-ZIP file with an unrecognized extension must be returned verbatim
+    /// as raw bytes — content sniffing must not alter non-archive handling.
+    #[test]
+    fn decompress_leaves_non_zip_unknown_extension_as_raw() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let plan = dir.path().join("notes.plan");
+        let body = b"plain text plan, definitely not a zip\n";
+        std::fs::write(&plan, body)?;
+
+        match decompress_once(&plan, Some(dir.path()))? {
+            CompressedContent::Raw(bytes) => assert_eq!(bytes, body),
+            other => panic!("expected Raw for non-zip file, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    /// A valid but empty ZIP begins with a ZIP signature yet extracts to zero
+    /// entries; it must fall back to raw bytes rather than being dropped.
+    #[test]
+    fn decompress_empty_zip_falls_back_to_raw() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let plan = dir.path().join("empty.plan");
+
+        let mut bytes = Vec::new();
+        {
+            let w = ZipWriter::new(std::io::Cursor::new(&mut bytes));
+            w.finish()?;
+        }
+        std::fs::write(&plan, &bytes)?;
+
+        match decompress_once(&plan, Some(dir.path()))? {
+            CompressedContent::Raw(raw) => assert_eq!(raw, bytes),
+            other => panic!("expected Raw for empty zip, got {other:?}"),
+        }
+
+        Ok(())
     }
 
     /// 1) Fully unpack:

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -717,18 +717,12 @@ fn decompress_once_with_single_stream_cap(
                     );
                 }
             }
-        } else {
+        } else if let Some(base) = base_dir {
             // Larger than the in-memory cap: stage the bytes and use the
             // streaming extractor (no total-input cap) instead of dropping to a
-            // raw scan of the compressed bytes.
-            let owned_temp;
-            let base = match base_dir {
-                Some(b) => b,
-                None => {
-                    owned_temp = tempdir()?;
-                    owned_temp.path()
-                }
-            };
+            // raw scan of the compressed bytes. Only viable when the caller owns
+            // a base dir the extracted files can live in; otherwise fall through
+            // to scanning the raw bytes.
             match extract_zip_bytes_via_streaming(&buffer, path, base) {
                 Ok(content) => return Ok(content),
                 Err(e) => {

--- a/src/scanner/enumerate.rs
+++ b/src/scanner/enumerate.rs
@@ -856,11 +856,23 @@ impl<'a> rayon::iter::ParallelIterator for GitRepoResultIter<'a> {
                 // We don't need to keep the raw archive bytes around — its
                 // compressed contents won't produce useful matches anyway.
                 if extract_archives {
+                    // Prefer an appearance whose name is a recognized archive so
+                    // report paths stay stable; fall back to the first appearance
+                    // only when the bytes are a ZIP with no archive extension.
                     let archive_path: Option<String> = md
                         .first_seen
                         .iter()
                         .map(|e| String::from_utf8_lossy(&e.path).to_string())
-                        .find(|p| is_compressed_content(Path::new(p), &data));
+                        .find(|p| is_compressed_file(Path::new(p)))
+                        .or_else(|| {
+                            if looks_like_zip(&data) {
+                                md.first_seen
+                                    .first()
+                                    .map(|e| String::from_utf8_lossy(&e.path).to_string())
+                            } else {
+                                None
+                            }
+                        });
 
                     if let Some(archive_path) = archive_path {
                         match try_extract_git_blob_archive(&archive_path, &data) {

--- a/src/scanner/enumerate.rs
+++ b/src/scanner/enumerate.rs
@@ -47,7 +47,7 @@ use crate::{
     scanner::{
         processing::BlobProcessor,
         runner::{create_datastore_channel, spawn_datastore_writer_thread},
-        util::{is_compressed_file, is_pyc_file, is_sqlite_file},
+        util::{is_compressed_content, is_compressed_file, is_pyc_file, is_sqlite_file},
     },
     scanner_pool::ScannerPool,
     sqlite::extract_sqlite_contents,
@@ -216,8 +216,13 @@ pub fn enumerate_filesystem_inputs(
                 };
                 // Check if this is an archive file. `blob_path()` covers both filesystem and git
                 // origins, so archive/binary filtering stays consistent across input modes.
-                let is_archive =
-                    origin.first().blob_path().map(is_compressed_file).unwrap_or(false);
+                // Byte sniffing also catches ZIP containers with no archive extension (e.g. a
+                // Terraform `tf.plan`).
+                let is_archive = origin
+                    .first()
+                    .blob_path()
+                    .map(|path| is_compressed_content(path, blob.bytes()))
+                    .unwrap_or(false);
                 let is_binary = is_binary(blob.bytes());
                 let should_skip = if is_archive {
                     // For archives: skip only if --no_extract_archives is true
@@ -341,6 +346,26 @@ impl<'a> ParallelIterator for FileResultIter<'a> {
     }
 }
 
+/// Peek a file's leading bytes to detect a ZIP container whose name carries no
+/// recognized archive extension (e.g. a Terraform `tf.plan`). Callers check the
+/// cheap [`is_compressed_file`] extension test first; this reads at most four
+/// bytes. A short read or I/O error is treated as "not an archive" so the
+/// caller falls back to its normal read path.
+fn file_header_looks_like_zip(path: &Path) -> bool {
+    use std::io::Read;
+
+    let mut header = [0u8; 4];
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    // A file shorter than the signature cannot be a ZIP, so a partial read is
+    // simply "not an archive".
+    if file.read_exact(&mut header).is_err() {
+        return false;
+    }
+    looks_like_zip(&header)
+}
+
 impl ParallelBlobIterator for FileResult {
     type Iter<'a> = FileResultIter<'a>;
 
@@ -392,7 +417,9 @@ impl ParallelBlobIterator for FileResult {
                     self.raw_blob_iter().map(Some)
                 }
             }
-        } else if extraction_enabled && is_compressed_file(&self.path) {
+        } else if extraction_enabled
+            && (is_compressed_file(&self.path) || file_header_looks_like_zip(&self.path))
+        {
             match decompress_file_to_temp(&self.path) {
                 Ok((content, _temp_dir)) => match content {
                     // Single-file decompression fully in memory.
@@ -539,7 +566,10 @@ fn try_extract_git_blob_archive(
     data: &[u8],
 ) -> Result<Option<Vec<(String, Vec<u8>)>>> {
     let pb = PathBuf::from(blob_path);
-    if !is_compressed_file(&pb) {
+    // A blob qualifies for extraction when its name matches a known archive
+    // format, or its bytes are a ZIP regardless of name (e.g. a `tfplan`).
+    let is_zip_body = looks_like_zip(data);
+    if !is_compressed_file(&pb) && !is_zip_body {
         return Ok(None);
     }
 
@@ -569,15 +599,16 @@ fn try_extract_git_blob_archive(
         .map(|s| s.to_ascii_lowercase())
         .filter(|ext| ZIP_BASED_FORMATS.iter().any(|z| z == ext));
 
-    if let Some(_ext) = zip_based_ext.as_ref() {
-        // Cheap magic-byte check first: if a `.zip`-named blob is not
-        // actually a ZIP (truncated download, stub file, accidental
-        // rename), skip extraction so the caller scans the raw bytes.
-        if !looks_like_zip(data) {
+    if zip_based_ext.is_some() || is_zip_body {
+        // A ZIP-based extension with non-ZIP bytes (truncated download, stub
+        // file, accidental rename) is skipped so the caller scans raw bytes.
+        if !is_zip_body {
             return Ok(None);
         }
         if data.len() <= MAX_INMEM_ZIP_ARCHIVE_BYTES {
             return match extract_zip_archive_in_memory(data, &archive_label) {
+                // No entries (e.g. an empty ZIP): let the caller scan raw bytes.
+                Ok(entries) if entries.is_empty() => Ok(None),
                 Ok(entries) => Ok(Some(entries)),
                 Err(e) => {
                     debug!(
@@ -820,15 +851,16 @@ impl<'a> rayon::iter::ParallelIterator for GitRepoResultIter<'a> {
                 let data = std::mem::take(&mut raw.data);
 
                 // Try archive extraction if any first-seen path looks like
-                // a known archive format. We don't need to keep the raw
-                // archive bytes around — its compressed contents won't
-                // produce useful matches anyway.
+                // a known archive format, or the blob bytes are a ZIP under a
+                // name with no archive extension (e.g. a committed `tfplan`).
+                // We don't need to keep the raw archive bytes around — its
+                // compressed contents won't produce useful matches anyway.
                 if extract_archives {
                     let archive_path: Option<String> = md
                         .first_seen
                         .iter()
                         .map(|e| String::from_utf8_lossy(&e.path).to_string())
-                        .find(|p| is_compressed_file(Path::new(p)));
+                        .find(|p| is_compressed_content(Path::new(p), &data));
 
                     if let Some(archive_path) = archive_path {
                         match try_extract_git_blob_archive(&archive_path, &data) {

--- a/src/scanner/util.rs
+++ b/src/scanner/util.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::decompress::ZIP_BASED_FORMATS;
+use crate::decompress::{ZIP_BASED_FORMATS, looks_like_zip};
 
 pub fn is_compressed_file(path: &Path) -> bool {
     // Get the full filename
@@ -35,6 +35,15 @@ pub fn is_compressed_file(path: &Path) -> bool {
     } else {
         false
     }
+}
+
+/// Like [`is_compressed_file`], but also recognizes ZIP containers by their
+/// leading magic bytes when the filename carries no known archive extension
+/// (e.g. a Terraform `tfplan`/`tf.plan`). The extension check short-circuits
+/// first, so recognized archives pay nothing extra and non-ZIP files are
+/// unaffected — [`looks_like_zip`] inspects at most the first four bytes.
+pub fn is_compressed_content(path: &Path, data: &[u8]) -> bool {
+    is_compressed_file(path) || looks_like_zip(data)
 }
 
 const SQLITE_EXTENSIONS: &[&str] = &["db", "sqlite", "sqlite3", "db3", "s3db", "sl3"];
@@ -72,7 +81,10 @@ pub fn has_sqlite_magic(data: &[u8]) -> bool {
 mod tests {
     use std::path::Path;
 
-    use super::is_compressed_file;
+    use super::{is_compressed_content, is_compressed_file};
+
+    /// Minimal but valid local-file-header ZIP signature.
+    const ZIP_MAGIC: &[u8] = b"PK\x03\x04";
 
     #[test]
     fn recognizes_tar_wrapped_long_compression_extensions() {
@@ -84,5 +96,30 @@ mod tests {
     fn recognizes_long_single_compression_extensions() {
         assert!(is_compressed_file(Path::new("payload.gzip")));
         assert!(is_compressed_file(Path::new("payload.bzip2")));
+    }
+
+    #[test]
+    fn content_sniffing_detects_zip_without_known_extension() {
+        // Terraform plan artifacts: a ZIP body under a non-archive name.
+        assert!(is_compressed_content(Path::new("tf.plan"), ZIP_MAGIC));
+        assert!(is_compressed_content(Path::new("tfplan"), ZIP_MAGIC));
+        assert!(is_compressed_content(Path::new("no_extension_at_all"), ZIP_MAGIC));
+    }
+
+    #[test]
+    fn content_sniffing_ignores_non_zip_files() {
+        // A file named like a plan but whose bytes are plain text must not be
+        // promoted to an archive: no drawbacks for non-ZIP content.
+        assert!(!is_compressed_content(Path::new("notes.plan"), b"just some text\n"));
+        assert!(!is_compressed_content(Path::new("empty.plan"), b""));
+        assert!(!is_compressed_content(Path::new("short.plan"), b"PK"));
+    }
+
+    #[test]
+    fn content_sniffing_still_honors_known_extensions() {
+        // Extension detection short-circuits before byte inspection, so a
+        // recognized archive is detected even with non-ZIP (or empty) bytes.
+        assert!(is_compressed_content(Path::new("archive.zip"), b""));
+        assert!(is_compressed_content(Path::new("archive.tar.gz"), b"not really gz"));
     }
 }

--- a/tests/smoke_tfplan.rs
+++ b/tests/smoke_tfplan.rs
@@ -1,0 +1,67 @@
+// tests/smoke_tfplan.rs
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+// A Terraform plan file is a ZIP archive under a name with no recognized
+// archive extension (`terraform plan -out=tfplan` yields a ZIP named `tfplan`;
+// `tf.plan` downloads use the generic `.plan` extension). Kingfisher must still
+// extract and scan the entries inside it rather than treat it as opaque bytes.
+#[test]
+fn smoke_scan_tfplan_zip_without_archive_extension() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let plan = dir.path().join("tf.plan");
+    let github_pat = "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";
+
+    // Build a ZIP (named like a Terraform plan) with the token inside a state
+    // entry and a `.tf` config entry.
+    {
+        use std::io::Write;
+
+        use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
+
+        let f = std::fs::File::create(&plan)?;
+        let mut zip = ZipWriter::new(f);
+        let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+        zip.start_file("tfstate", opts)?;
+        zip.write_all(format!("token={github_pat}\n").as_bytes())?;
+        zip.start_file("tfconfig/main.tf", opts)?;
+        zip.write_all(b"variable \"region\" { default = \"us-east-1\" }\n")?;
+        zip.finish()?;
+    }
+
+    let findings_code = 200;
+
+    // ── extraction ENABLED (default) -- secret should be found ──────────────────
+    Command::new(assert_cmd::cargo::cargo_bin!("kingfisher"))
+        .args([
+            "scan",
+            plan.to_str().unwrap(),
+            "--confidence=low",
+            "--format",
+            "json",
+            "--no-update-check",
+        ])
+        .assert()
+        .code(findings_code)
+        .stdout(predicates::str::contains(github_pat));
+
+    // ── extraction DISABLED -- secret *not* found ───────────────────────────────
+    Command::new(assert_cmd::cargo::cargo_bin!("kingfisher"))
+        .args([
+            "scan",
+            plan.to_str().unwrap(),
+            "--confidence=low",
+            "--format",
+            "json",
+            "--no-extract-archives",
+            "--no-update-check",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(github_pat).not());
+
+    dir.close()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Kingfisher decided whether to extract an archive purely by file extension (`is_compressed_file`). A Terraform plan file is a real ZIP (`terraform plan -out=tfplan` produces a ZIP named `tfplan`; `tf.plan` downloads use the generic `.plan` extension), so it was scanned as opaque compressed bytes and no secrets inside `tfstate`/`tfstate-prev`/`*.tf` were found.

This PR adds content-based ZIP detection: a file whose bytes begin with a ZIP signature is extracted regardless of its name, reusing the existing `looks_like_zip()` magic-byte helper.

### Motivation

Terraform plans routinely embed provider credentials, state outputs, and tokens. They are a common artifact in CI logs and developer machines, and their default names carry no archive extension, so they slipped through extension-only detection.

### Why not an extension allowlist

Adding `plan`/`tfplan` to the recognized extensions would attempt ZIP extraction on unrelated `*.plan` files (plain-text plans, etc.). Content sniffing only promotes files that actually start with a ZIP signature, so non-ZIP files are untouched.

## Changes

- `src/scanner/util.rs`: add `is_compressed_content(path, data)`, the cheap extension check short-circuits first, falling back to a ZIP magic-byte check.
- `src/decompress.rs`: the unknown-extension branch now content-sniffs the already-read buffer and routes real ZIPs through the existing bounded in-memory extractor.
- `src/scanner/enumerate.rs`: the filesystem gate peeks the 4-byte header (only when the extension check fails), and both the blob-classification path and the git-history path use content detection.

## Safety / performance

- No new extraction code: content-detected ZIPs go through the same extractors, so zip-slip protection (`is_safe_extract_path`) and zip-bomb caps (64 MB compressed / 256 MB aggregate / 512 MB per-entry / extraction depth) are unchanged.
- Empty or unreadable ZIPs fall back to raw-byte scanning rather than being dropped.
- The only added cost is a single 4-byte header read per file whose extension is not already a recognized archive; other checks operate on in-memory bytes.
- Respects `--no-extract-archives` (the file is then skipped as an archive) and `--no-binary`.

## Testing

- Unit tests for `is_compressed_content` (ZIP-by-content, non-ZIP `.plan`, empty/short input, known extensions still honored).
- Decompressor tests: a ZIP named `tf.plan` extracts its entries; a non-ZIP `.plan` and a valid *empty* ZIP fall back to raw bytes.
- `tests/smoke_tfplan.rs`: end-to-end scan of a runtime-generated `tf.plan` finds the embedded secret with extraction enabled, and finds nothing with `--no-extract-archives`.
- Verified against a real Terraform plan: 0 → 9 findings across the extracted entries (AWS keys, Vault token, JWT, bcrypt hashes), with `--no-extract-archives` still yielding 0.
- Full suite green (`cargo fmt --check`, `cargo clippy -D warnings`, 522 lib unit tests, archive smoke tests).