### PR TITLE
fix: exclude hidden matches from findings by rule

### DIFF
--- a/src/findings_store.rs
+++ b/src/findings_store.rs
@@ -359,12 +359,19 @@ impl FindingsStore {
             .count()
     }
 
+    /// Returns counts by rule name for user-visible matches.
     pub fn get_summary(&self) -> FxHashMap<&'static str, usize> {
-        self.matches.iter().fold(FxHashMap::default(), |mut acc, msg| {
-            let (_, _, m) = &**msg;
-            *acc.entry(intern(m.rule.name())).or_insert(0) += 1;
-            acc
-        })
+        self.matches
+            .iter()
+            .filter(|msg| {
+                let (_, _, match_item) = msg.as_ref();
+                match_item.visible
+            })
+            .fold(FxHashMap::default(), |mut acc, msg| {
+                let (_, _, m) = &**msg;
+                *acc.entry(intern(m.rule.name())).or_insert(0) += 1;
+                acc
+            })
     }
 
     pub fn clone_destination(&self, repo_url: &GitUrl) -> PathBuf {

--- a/tests/dependent_rule_dedup.rs
+++ b/tests/dependent_rule_dedup.rs
@@ -35,7 +35,7 @@ fn make_rule(
     }))
 }
 
-fn make_match(rule: Arc<Rule>, blob_id: BlobId, value: &str) -> Match {
+fn make_match(rule: Arc<Rule>, blob_id: BlobId, value: &str, visible: bool) -> Match {
     Match {
         location: Location::with_source_span(
             OffsetSpan { start: 0, end: value.len() },
@@ -60,7 +60,7 @@ fn make_match(rule: Arc<Rule>, blob_id: BlobId, value: &str) -> Match {
         validation_response_status: 0,
         validation_success: false,
         calculated_entropy: 0.0,
-        visible: true,
+        visible,
         is_base64: false,
         dependent_captures: std::collections::BTreeMap::new(),
     }
@@ -107,9 +107,9 @@ fn dedup_preserves_dependency_provider_matches_per_blob() -> Result<()> {
         record_match(
             &origin,
             &blob_a,
-            make_match(provider_rule.clone(), blob_a.id, "shared_token"),
+            make_match(provider_rule.clone(), blob_a.id, "shared_token", false),
         ),
-        record_match(&origin, &blob_b, make_match(provider_rule, blob_b.id, "shared_token")),
+        record_match(&origin, &blob_b, make_match(provider_rule, blob_b.id, "shared_token", false)),
     ];
 
     store.record(matches, true);
@@ -140,13 +140,71 @@ fn dedup_still_merges_non_dependency_rules_across_blobs() -> Result<()> {
     });
 
     let matches = vec![
-        record_match(&origin, &blob_a, make_match(rule.clone(), blob_a.id, "shared_token")),
-        record_match(&origin, &blob_b, make_match(rule, blob_b.id, "shared_token")),
+        record_match(&origin, &blob_a, make_match(rule.clone(), blob_a.id, "shared_token", true)),
+        record_match(&origin, &blob_b, make_match(rule, blob_b.id, "shared_token", true)),
     ];
 
     store.record(matches, true);
 
     assert_eq!(store.get_matches().len(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn summary_only_counts_visible_matches() -> Result<()> {
+    let visible_rule = make_rule("RULE.VISIBLE", true, vec![]);
+    let hidden_rule = make_rule("RULE.HIDDEN", false, vec![]);
+    let mut store = FindingsStore::new(PathBuf::from("/tmp"));
+
+    let origin = Arc::new(OriginSet::single(Origin::from_file(PathBuf::from("summary.txt"))));
+    let visible_blob = Arc::new(BlobMetadata {
+        id: BlobId::new(b"visible"),
+        num_bytes: 10,
+        mime_essence: None,
+        language: None,
+    });
+    let suppressed_blob = Arc::new(BlobMetadata {
+        id: BlobId::new(b"suppressed"),
+        num_bytes: 10,
+        mime_essence: None,
+        language: None,
+    });
+    let hidden_blob = Arc::new(BlobMetadata {
+        id: BlobId::new(b"hidden"),
+        num_bytes: 10,
+        mime_essence: None,
+        language: None,
+    });
+
+    store.record(
+        vec![
+            record_match(
+                &origin,
+                &visible_blob,
+                make_match(visible_rule.clone(), visible_blob.id, "visible", true),
+            ),
+            record_match(
+                &origin,
+                &suppressed_blob,
+                make_match(visible_rule, suppressed_blob.id, "suppressed", false),
+            ),
+            record_match(
+                &origin,
+                &hidden_blob,
+                make_match(hidden_rule, hidden_blob.id, "hidden", false),
+            ),
+        ],
+        false,
+    );
+
+    assert_eq!(store.get_matches().len(), 3, "hidden matches must remain in the store");
+    assert_eq!(store.get_num_matches(), 1);
+
+    let summary = store.get_summary();
+    assert_eq!(summary.len(), 1);
+    assert_eq!(summary.get("RULE.VISIBLE rule"), Some(&1));
+    assert!(!summary.contains_key("RULE.HIDDEN rule"));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- exclude matches with `Match.visible == false` from `FindingsStore::get_summary()`
- retain hidden matches in the store for dependency-rule and internal processing
- cover both hidden helper rules and dynamically suppressed matches from otherwise visible rules

This aligns `findings_by_rule` with the match-level visibility semantics already used by `findings`. It does not change scanning, validation, deduplication, detailed findings, exit behavior, or the existing `--no-dedup` origin weighting.

## Testing

- `make tests`
- `cargo fmt --all -- --check`
- `cargo clippy -p kingfisher --test dependent_rule_dedup -- -D warnings -A clippy::large_enum_variant -A clippy::explicit_counter_loop`
- `cargo test --test dependent_rule_dedup` (3 passed)
- `cargo test --lib findings_store` (2 passed, 528 filtered)
- focused regression repeated 20 times

The two Clippy allowances correspond to existing Rust 1.96 warnings in unchanged `src/cli/global.rs` and `src/decompress.rs`.

Fixes #449