### PR TITLE
Support Jira Cloud and Confluence Cloud in the jira/confluence scanners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8195,6 +8195,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
+ "futures",
  "parking_lot",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,7 @@ system-alloc = [] # Darwin-only: force the system allocator
 
 [dev-dependencies]
 pretty_assertions = "1.4"
-temp-env = "0.3.6"
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 wiremock = "0.6.5"
 git2 = { version = "0.21.0", default-features = false }
 rand_chacha = "0.10.0"

--- a/README.md
+++ b/README.md
@@ -761,7 +761,9 @@ KF_POSTMAN_TOKEN="PMAK-..." kingfisher scan postman --all
 | `KF_HUGGINGFACE_TOKEN` | Hugging Face access token for API enumeration and git cloning |
 | `KF_HUGGINGFACE_USERNAME` | Optional username for Hugging Face git operations (defaults to `hf_user`) |
 | `KF_JIRA_TOKEN`   | Jira API token               |
+| `KF_JIRA_USER`    | Jira account email; when set, sends `KF_JIRA_TOKEN` as Basic auth (required for Jira Cloud API tokens) |
 | `KF_CONFLUENCE_TOKEN` | Confluence API token      |
+| `KF_CONFLUENCE_USER` | Confluence account email; when set, sends `KF_CONFLUENCE_TOKEN` as Basic auth (required for Confluence Cloud API tokens) |
 | `KF_SLACK_TOKEN`  | Slack API token              |
 | `KF_TEAMS_TOKEN`  | Microsoft Graph API token for Teams message search |
 | `KF_POSTMAN_TOKEN` / `POSTMAN_API_KEY` | Postman API key for workspace, collection, and environment scanning |

--- a/crates/kingfisher-rules/data/rules/atlassian.yml
+++ b/crates/kingfisher-rules/data/rules/atlassian.yml
@@ -5,6 +5,8 @@ rules:
       (?xi)                       
       \b                         
       atlassian
+      [^\n\r]{0,20}?
+      (?: api[_\-\s]?token | api[_\-\s]?key | token | key | secret | password )
       (?:.|[\n\r]){0,32}?
       \b                         
       (

--- a/crates/kingfisher-rules/data/rules/atlassian.yml
+++ b/crates/kingfisher-rules/data/rules/atlassian.yml
@@ -5,8 +5,10 @@ rules:
       (?xi)                       
       \b                         
       atlassian
-      [^\n\r]{0,20}?
-      (?: api[_\-\s]?token | api[_\-\s]?key | token | key | secret | password )
+      (?:.|[\n\r]){0,20}?
+      [^[:alnum:]]
+      (?:api[_-]?token|api[_-]?key|token|key|secret|password)
+      \b
       (?:.|[\n\r]){0,32}?
       \b                         
       (

--- a/docs-site/docs/usage/basic-scanning.md
+++ b/docs-site/docs/usage/basic-scanning.md
@@ -1303,6 +1303,21 @@ KF_JIRA_TOKEN="token" kingfisher scan jira --url https://jira.mongodb.org \
   --max-results 1000
 ```
 
+### Jira Cloud
+
+Use the full `*.atlassian.net` site URL for `--url`. Kingfisher detects Jira Cloud from the hostname and automatically issues JQL searches against the enhanced `/rest/api/3/search/jql` endpoint instead of the legacy `/rest/api/2/search` endpoint, which Atlassian has removed for Cloud sites.
+
+Jira Cloud API tokens authenticate with HTTP Basic auth (account email + token), not a bearer token. Set `KF_JIRA_USER` to your Jira Cloud account email alongside `KF_JIRA_TOKEN` to switch Kingfisher to Basic auth:
+
+```bash
+KF_JIRA_USER="user@example.com" KF_JIRA_TOKEN="token" \
+  kingfisher scan jira --url https://example.atlassian.net \
+    --jql "project = TEST AND status = Open" \
+    --max-results 500
+```
+
+Generate the API token from [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens). Jira Server/Data Center Personal Access Tokens keep working as a bearer token when `KF_JIRA_USER` is unset.
+
 ---
 
 ## Confluence
@@ -1322,7 +1337,7 @@ KF_CONFLUENCE_USER="user@example.com" KF_CONFLUENCE_TOKEN="token" \
     --max-results 500
 ```
 
-Use the base URL of your Confluence site for `--url`. Kingfisher automatically adds `/rest/api` to the end, so `https://example.com/wiki` and `https://example.com` both work depending on your server configuration.
+Use the base URL of your Confluence site for `--url`. Kingfisher automatically adds `/rest/api` to the end, so `https://example.com/wiki` and `https://example.com` both work depending on your server configuration. For Confluence Cloud, include the `/wiki` path segment Atlassian adds to Cloud sites, e.g. `--url https://example.atlassian.net/wiki`, and set `KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API tokens require Basic auth, not a bearer token. Kingfisher paginates results by following the server-issued `next` link rather than an offset, since Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
 
 Generate a personal access token and set it in the `KF_CONFLUENCE_TOKEN` environment variable. By default, Kingfisher sends the token as a bearer token in the `Authorization` header.
 
@@ -1516,7 +1531,9 @@ This distinction helps you understand validation coverage: **Failed Validations*
 | `KF_HUGGINGFACE_TOKEN` | Hugging Face access token for API enumeration and git cloning |
 | `KF_HUGGINGFACE_USERNAME` | Optional username for Hugging Face git operations (defaults to `hf_user`) |
 | `KF_JIRA_TOKEN`   | Jira API token               |
+| `KF_JIRA_USER`    | Jira account email; when set, sends `KF_JIRA_TOKEN` as Basic auth (required for Jira Cloud API tokens) |
 | `KF_CONFLUENCE_TOKEN` | Confluence API token      |
+| `KF_CONFLUENCE_USER` | Confluence account email; when set, sends `KF_CONFLUENCE_TOKEN` as Basic auth (required for Confluence Cloud API tokens) |
 | `KF_SLACK_TOKEN`  | Slack API token              |
 | `KF_TEAMS_TOKEN`  | Microsoft Graph API token for Teams message search |
 | `KF_DOCKER_TOKEN` | Docker registry token (`user:pass` or bearer token). If unset, credentials from the Docker keychain are used |
@@ -1538,6 +1555,8 @@ To authenticate Jira requests:
 
 ```bash
 export KF_JIRA_TOKEN="token"
+# Jira Cloud API tokens additionally require the account email:
+export KF_JIRA_USER="user@example.com"
 ```
 
 To authenticate Confluence requests:

--- a/docs-site/docs/usage/basic-scanning.md
+++ b/docs-site/docs/usage/basic-scanning.md
@@ -1343,7 +1343,7 @@ KF_CONFLUENCE_USER="user@example.com" KF_CONFLUENCE_TOKEN="token" \
     --max-results 500
 ```
 
-Use the base URL of your Confluence site for `--url`. Kingfisher automatically adds `/rest/api` to the end, so `https://example.com/wiki` and `https://example.com` both work depending on your server configuration. For Confluence Cloud, include the `/wiki` path segment Atlassian adds to Cloud sites, e.g. `--url https://example.atlassian.net/wiki`, and set `KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API tokens require Basic auth, not a bearer token. Kingfisher paginates results by following the server-issued `next` link rather than an offset, since Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
+Use the base URL of your Confluence site for `--url`. Kingfisher automatically adds `/rest/api` to the end, so `https://example.com/wiki` and `https://example.com` both work depending on your server configuration. For Confluence Cloud, pass the site URL as-is (`--url https://example.atlassian.net`): Cloud serves its API under a `/wiki` context path, and Kingfisher adds that segment for `*.atlassian.net` hosts, so both that form and the explicit `https://example.atlassian.net/wiki` work. Also set `KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API tokens require Basic auth, not a bearer token. Kingfisher paginates results by following the server-issued `next` link rather than an offset, since Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
 
 Generate a personal access token and set it in the `KF_CONFLUENCE_TOKEN` environment variable. By default, Kingfisher sends the token as a bearer token in the `Authorization` header.
 

--- a/docs-site/docs/usage/basic-scanning.md
+++ b/docs-site/docs/usage/basic-scanning.md
@@ -1318,6 +1318,8 @@ KF_JIRA_USER="user@example.com" KF_JIRA_TOKEN="token" \
 
 Generate the API token from [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens). Jira Server/Data Center Personal Access Tokens keep working as a bearer token when `KF_JIRA_USER` is unset.
 
+Searches request `fields=*all`, so issue descriptions and custom text fields are scanned on both Cloud and Server/Data Center. Jira Cloud's search endpoint returns only `id`, `key`, `summary`, and `status` when `fields` is left unset, which would silently exclude descriptions from the scan.
+
 ---
 
 ## Confluence

--- a/docs-site/docs/usage/basic-scanning.md
+++ b/docs-site/docs/usage/basic-scanning.md
@@ -1320,6 +1320,8 @@ Generate the API token from [id.atlassian.com](https://id.atlassian.com/manage-p
 
 Searches request `fields=*all`, so issue descriptions and custom text fields are scanned on both Cloud and Server/Data Center. Jira Cloud's search endpoint returns only `id`, `key`, `summary`, and `status` when `fields` is left unset, which would silently exclude descriptions from the scan.
 
+`--max-results` is a total, not a page size: searches page through results 100 issues at a time until that many issues have been collected, following Jira Cloud's cursor or Server/Data Center's offset as appropriate.
+
 ---
 
 ## Confluence

--- a/docs-site/docs/usage/basic-scanning.md
+++ b/docs-site/docs/usage/basic-scanning.md
@@ -1322,6 +1322,8 @@ Searches request `fields=*all`, so issue descriptions and custom text fields are
 
 `--max-results` is a total, not a page size: searches page through results 100 issues at a time until that many issues have been collected, following Jira Cloud's cursor or Server/Data Center's offset as appropriate.
 
+Pass `--all` instead of `--max-results` to keep paging for as long as Jira returns issues, stopping only on the last page. `kingfisher scan confluence --all` does the same for CQL queries. The two flags are mutually exclusive.
+
 ---
 
 ## Confluence

--- a/docs-site/docs/usage/integrations.md
+++ b/docs-site/docs/usage/integrations.md
@@ -776,6 +776,11 @@ Generate the API token from
 Jira Server/Data Center Personal Access Tokens keep working as a bearer
 token when `KF_JIRA_USER` is unset.
 
+Searches request `fields=*all`, so issue descriptions and custom text fields
+are scanned on both Cloud and Server/Data Center. Jira Cloud's search endpoint
+returns only `id`, `key`, `summary`, and `status` when `fields` is left unset,
+which would silently exclude descriptions from the scan.
+
 ## Confluence
 
 ### Scan Confluence pages matching a CQL query

--- a/docs-site/docs/usage/integrations.md
+++ b/docs-site/docs/usage/integrations.md
@@ -753,6 +753,29 @@ KF_JIRA_TOKEN="token" kingfisher scan jira --url https://jira.mongodb.org \
   --max-results 1000
 ```
 
+### Jira Cloud
+
+Use the full `*.atlassian.net` site URL for `--url`. Kingfisher detects Jira
+Cloud from the hostname and automatically issues JQL searches against the
+enhanced `/rest/api/3/search/jql` endpoint instead of the legacy
+`/rest/api/2/search` endpoint, which Atlassian has removed for Cloud sites.
+
+Jira Cloud API tokens authenticate with HTTP Basic auth (account email +
+token), not a bearer token. Set `KF_JIRA_USER` to your Jira Cloud account
+email alongside `KF_JIRA_TOKEN` to switch Kingfisher to Basic auth:
+
+```bash
+KF_JIRA_USER="user@example.com" KF_JIRA_TOKEN="token" \
+  kingfisher scan jira --url https://example.atlassian.net \
+    --jql "project = TEST AND status = Open" \
+    --max-results 500
+```
+
+Generate the API token from
+[id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens).
+Jira Server/Data Center Personal Access Tokens keep working as a bearer
+token when `KF_JIRA_USER` is unset.
+
 ## Confluence
 
 ### Scan Confluence pages matching a CQL query
@@ -772,7 +795,13 @@ KF_CONFLUENCE_USER="user@example.com" KF_CONFLUENCE_TOKEN="token" \
 
 Use the base URL of your Confluence site for `--url`. Kingfisher
 automatically adds `/rest/api` to the end, so `https://example.com/wiki` and
-`https://example.com` both work depending on your server configuration.
+`https://example.com` both work depending on your server configuration. For
+Confluence Cloud, include the `/wiki` path segment Atlassian adds to Cloud
+sites, e.g. `--url https://example.atlassian.net/wiki`, and set
+`KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API
+tokens require Basic auth, not a bearer token. Kingfisher paginates results
+by following the server-issued `next` link rather than an offset, since
+Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
 
 Generate a personal access token and set it in the `KF_CONFLUENCE_TOKEN` environment variable. By default, Kingfisher sends the token as a bearer token in the `Authorization` header.
 
@@ -894,7 +923,9 @@ The token is sent as the `X-Api-Key` header. Either `KF_POSTMAN_TOKEN` or `POSTM
 | `KF_HUGGINGFACE_TOKEN` | Hugging Face access token for API enumeration and git cloning |
 | `KF_HUGGINGFACE_USERNAME` | Optional username for Hugging Face git operations (defaults to `hf_user`) |
 | `KF_JIRA_TOKEN`   | Jira API token               |
+| `KF_JIRA_USER`    | Jira account email; when set, sends `KF_JIRA_TOKEN` as Basic auth (required for Jira Cloud API tokens) |
 | `KF_CONFLUENCE_TOKEN` | Confluence API token      |
+| `KF_CONFLUENCE_USER` | Confluence account email; when set, sends `KF_CONFLUENCE_TOKEN` as Basic auth (required for Confluence Cloud API tokens) |
 | `KF_SLACK_TOKEN`  | Slack API token              |
 | `KF_TEAMS_TOKEN`  | Microsoft Graph API token for Teams message search |
 | `KF_POSTMAN_TOKEN` / `POSTMAN_API_KEY` | Postman API key (sent as `X-Api-Key`) for workspace, collection, and environment scanning |
@@ -916,6 +947,8 @@ export KF_GITLAB_TOKEN="glpat-…"
 To authenticate Jira requests:
 ```bash
 export KF_JIRA_TOKEN="token"
+# Jira Cloud API tokens additionally require the account email:
+export KF_JIRA_USER="user@example.com"
 ```
 
 To authenticate Confluence requests:

--- a/docs-site/docs/usage/integrations.md
+++ b/docs-site/docs/usage/integrations.md
@@ -781,6 +781,10 @@ are scanned on both Cloud and Server/Data Center. Jira Cloud's search endpoint
 returns only `id`, `key`, `summary`, and `status` when `fields` is left unset,
 which would silently exclude descriptions from the scan.
 
+`--max-results` is a total, not a page size: searches page through results
+100 issues at a time until that many issues have been collected, following
+Jira Cloud's cursor or Server/Data Center's offset as appropriate.
+
 ## Confluence
 
 ### Scan Confluence pages matching a CQL query

--- a/docs-site/docs/usage/integrations.md
+++ b/docs-site/docs/usage/integrations.md
@@ -818,10 +818,12 @@ KF_CONFLUENCE_USER="user@example.com" KF_CONFLUENCE_TOKEN="token" \
 Use the base URL of your Confluence site for `--url`. Kingfisher
 automatically adds `/rest/api` to the end, so `https://example.com/wiki` and
 `https://example.com` both work depending on your server configuration. For
-Confluence Cloud, include the `/wiki` path segment Atlassian adds to Cloud
-sites, e.g. `--url https://example.atlassian.net/wiki`, and set
-`KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API
-tokens require Basic auth, not a bearer token. Kingfisher paginates results
+Confluence Cloud, pass the site URL as-is (`--url https://example.atlassian.net`):
+Cloud serves its API under a `/wiki` context path, and Kingfisher adds that
+segment for `*.atlassian.net` hosts, so both that form and the explicit
+`https://example.atlassian.net/wiki` work. Also set `KF_CONFLUENCE_USER` to your
+Cloud account email — Confluence Cloud API tokens require Basic auth, not a
+bearer token. Kingfisher paginates results
 by following the server-issued `next` link rather than an offset, since
 Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
 

--- a/docs-site/docs/usage/integrations.md
+++ b/docs-site/docs/usage/integrations.md
@@ -785,6 +785,19 @@ which would silently exclude descriptions from the scan.
 100 issues at a time until that many issues have been collected, following
 Jira Cloud's cursor or Server/Data Center's offset as appropriate.
 
+Pass `--all` instead of `--max-results` to keep paging for as long as Jira
+returns issues, stopping only on the last page:
+
+```bash
+KF_JIRA_USER="user@example.com" KF_JIRA_TOKEN="token" \
+  kingfisher scan jira --url https://example.atlassian.net \
+    --jql "project = TEST" \
+    --all
+```
+
+`kingfisher scan confluence --all` does the same for CQL queries. The two
+flags are mutually exclusive.
+
 ## Confluence
 
 ### Scan Confluence pages matching a CQL query

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -778,6 +778,10 @@ are scanned on both Cloud and Server/Data Center. Jira Cloud's search endpoint
 returns only `id`, `key`, `summary`, and `status` when `fields` is left unset,
 which would silently exclude descriptions from the scan.
 
+`--max-results` is a total, not a page size: searches page through results
+100 issues at a time until that many issues have been collected, following
+Jira Cloud's cursor or Server/Data Center's offset as appropriate.
+
 ## Confluence
 
 ### Scan Confluence pages matching a CQL query

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -782,6 +782,19 @@ which would silently exclude descriptions from the scan.
 100 issues at a time until that many issues have been collected, following
 Jira Cloud's cursor or Server/Data Center's offset as appropriate.
 
+Pass `--all` instead of `--max-results` to keep paging for as long as Jira
+returns issues, stopping only on the last page:
+
+```bash
+KF_JIRA_USER="user@example.com" KF_JIRA_TOKEN="token" \
+  kingfisher scan jira --url https://example.atlassian.net \
+    --jql "project = TEST" \
+    --all
+```
+
+`kingfisher scan confluence --all` does the same for CQL queries. The two
+flags are mutually exclusive.
+
 ## Confluence
 
 ### Scan Confluence pages matching a CQL query

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -815,10 +815,12 @@ KF_CONFLUENCE_USER="user@example.com" KF_CONFLUENCE_TOKEN="token" \
 Use the base URL of your Confluence site for `--url`. Kingfisher
 automatically adds `/rest/api` to the end, so `https://example.com/wiki` and
 `https://example.com` both work depending on your server configuration. For
-Confluence Cloud, include the `/wiki` path segment Atlassian adds to Cloud
-sites, e.g. `--url https://example.atlassian.net/wiki`, and set
-`KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API
-tokens require Basic auth, not a bearer token. Kingfisher paginates results
+Confluence Cloud, pass the site URL as-is (`--url https://example.atlassian.net`):
+Cloud serves its API under a `/wiki` context path, and Kingfisher adds that
+segment for `*.atlassian.net` hosts, so both that form and the explicit
+`https://example.atlassian.net/wiki` work. Also set `KF_CONFLUENCE_USER` to your
+Cloud account email — Confluence Cloud API tokens require Basic auth, not a
+bearer token. Kingfisher paginates results
 by following the server-issued `next` link rather than an offset, since
 Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -773,6 +773,11 @@ Generate the API token from
 Jira Server/Data Center Personal Access Tokens keep working as a bearer
 token when `KF_JIRA_USER` is unset.
 
+Searches request `fields=*all`, so issue descriptions and custom text fields
+are scanned on both Cloud and Server/Data Center. Jira Cloud's search endpoint
+returns only `id`, `key`, `summary`, and `status` when `fields` is left unset,
+which would silently exclude descriptions from the scan.
+
 ## Confluence
 
 ### Scan Confluence pages matching a CQL query

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -750,6 +750,29 @@ KF_JIRA_TOKEN="token" kingfisher scan jira --url https://jira.mongodb.org \
   --max-results 1000
 ```
 
+### Jira Cloud
+
+Use the full `*.atlassian.net` site URL for `--url`. Kingfisher detects Jira
+Cloud from the hostname and automatically issues JQL searches against the
+enhanced `/rest/api/3/search/jql` endpoint instead of the legacy
+`/rest/api/2/search` endpoint, which Atlassian has removed for Cloud sites.
+
+Jira Cloud API tokens authenticate with HTTP Basic auth (account email +
+token), not a bearer token. Set `KF_JIRA_USER` to your Jira Cloud account
+email alongside `KF_JIRA_TOKEN` to switch Kingfisher to Basic auth:
+
+```bash
+KF_JIRA_USER="user@example.com" KF_JIRA_TOKEN="token" \
+  kingfisher scan jira --url https://example.atlassian.net \
+    --jql "project = TEST AND status = Open" \
+    --max-results 500
+```
+
+Generate the API token from
+[id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens).
+Jira Server/Data Center Personal Access Tokens keep working as a bearer
+token when `KF_JIRA_USER` is unset.
+
 ## Confluence
 
 ### Scan Confluence pages matching a CQL query
@@ -769,7 +792,13 @@ KF_CONFLUENCE_USER="user@example.com" KF_CONFLUENCE_TOKEN="token" \
 
 Use the base URL of your Confluence site for `--url`. Kingfisher
 automatically adds `/rest/api` to the end, so `https://example.com/wiki` and
-`https://example.com` both work depending on your server configuration.
+`https://example.com` both work depending on your server configuration. For
+Confluence Cloud, include the `/wiki` path segment Atlassian adds to Cloud
+sites, e.g. `--url https://example.atlassian.net/wiki`, and set
+`KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API
+tokens require Basic auth, not a bearer token. Kingfisher paginates results
+by following the server-issued `next` link rather than an offset, since
+Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
 
 Generate a personal access token and set it in the `KF_CONFLUENCE_TOKEN` environment variable. By default, Kingfisher sends the token as a bearer token in the `Authorization` header.
 
@@ -891,7 +920,9 @@ The token is sent as the `X-Api-Key` header. Either `KF_POSTMAN_TOKEN` or `POSTM
 | `KF_HUGGINGFACE_TOKEN` | Hugging Face access token for API enumeration and git cloning |
 | `KF_HUGGINGFACE_USERNAME` | Optional username for Hugging Face git operations (defaults to `hf_user`) |
 | `KF_JIRA_TOKEN`   | Jira API token               |
+| `KF_JIRA_USER`    | Jira account email; when set, sends `KF_JIRA_TOKEN` as Basic auth (required for Jira Cloud API tokens) |
 | `KF_CONFLUENCE_TOKEN` | Confluence API token      |
+| `KF_CONFLUENCE_USER` | Confluence account email; when set, sends `KF_CONFLUENCE_TOKEN` as Basic auth (required for Confluence Cloud API tokens) |
 | `KF_SLACK_TOKEN`  | Slack API token              |
 | `KF_TEAMS_TOKEN`  | Microsoft Graph API token for Teams message search |
 | `KF_POSTMAN_TOKEN` / `POSTMAN_API_KEY` | Postman API key (sent as `X-Api-Key`) for workspace, collection, and environment scanning |
@@ -913,6 +944,8 @@ export KF_GITLAB_TOKEN="glpat-…"
 To authenticate Jira requests:
 ```bash
 export KF_JIRA_TOKEN="token"
+# Jira Cloud API tokens additionally require the account email:
+export KF_JIRA_USER="user@example.com"
 ```
 
 To authenticate Confluence requests:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1317,6 +1317,8 @@ Searches request `fields=*all`, so issue descriptions and custom text fields are
 
 `--max-results` is a total, not a page size: searches page through results 100 issues at a time until that many issues have been collected, following Jira Cloud's cursor or Server/Data Center's offset as appropriate.
 
+Pass `--all` instead of `--max-results` to keep paging for as long as Jira returns issues, stopping only on the last page. `kingfisher scan confluence --all` does the same for CQL queries. The two flags are mutually exclusive.
+
 ---
 
 ## Confluence

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1315,6 +1315,8 @@ Generate the API token from [id.atlassian.com](https://id.atlassian.com/manage-p
 
 Searches request `fields=*all`, so issue descriptions and custom text fields are scanned on both Cloud and Server/Data Center. Jira Cloud's search endpoint returns only `id`, `key`, `summary`, and `status` when `fields` is left unset, which would silently exclude descriptions from the scan.
 
+`--max-results` is a total, not a page size: searches page through results 100 issues at a time until that many issues have been collected, following Jira Cloud's cursor or Server/Data Center's offset as appropriate.
+
 ---
 
 ## Confluence

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1298,6 +1298,21 @@ KF_JIRA_TOKEN="token" kingfisher scan jira --url https://jira.mongodb.org \
   --max-results 1000
 ```
 
+### Jira Cloud
+
+Use the full `*.atlassian.net` site URL for `--url`. Kingfisher detects Jira Cloud from the hostname and automatically issues JQL searches against the enhanced `/rest/api/3/search/jql` endpoint instead of the legacy `/rest/api/2/search` endpoint, which Atlassian has removed for Cloud sites.
+
+Jira Cloud API tokens authenticate with HTTP Basic auth (account email + token), not a bearer token. Set `KF_JIRA_USER` to your Jira Cloud account email alongside `KF_JIRA_TOKEN` to switch Kingfisher to Basic auth:
+
+```bash
+KF_JIRA_USER="user@example.com" KF_JIRA_TOKEN="token" \
+  kingfisher scan jira --url https://example.atlassian.net \
+    --jql "project = TEST AND status = Open" \
+    --max-results 500
+```
+
+Generate the API token from [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens). Jira Server/Data Center Personal Access Tokens keep working as a bearer token when `KF_JIRA_USER` is unset.
+
 ---
 
 ## Confluence
@@ -1317,7 +1332,7 @@ KF_CONFLUENCE_USER="user@example.com" KF_CONFLUENCE_TOKEN="token" \
     --max-results 500
 ```
 
-Use the base URL of your Confluence site for `--url`. Kingfisher automatically adds `/rest/api` to the end, so `https://example.com/wiki` and `https://example.com` both work depending on your server configuration.
+Use the base URL of your Confluence site for `--url`. Kingfisher automatically adds `/rest/api` to the end, so `https://example.com/wiki` and `https://example.com` both work depending on your server configuration. For Confluence Cloud, include the `/wiki` path segment Atlassian adds to Cloud sites, e.g. `--url https://example.atlassian.net/wiki`, and set `KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API tokens require Basic auth, not a bearer token. Kingfisher paginates results by following the server-issued `next` link rather than an offset, since Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
 
 Generate a personal access token and set it in the `KF_CONFLUENCE_TOKEN` environment variable. By default, Kingfisher sends the token as a bearer token in the `Authorization` header.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1313,6 +1313,8 @@ KF_JIRA_USER="user@example.com" KF_JIRA_TOKEN="token" \
 
 Generate the API token from [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens). Jira Server/Data Center Personal Access Tokens keep working as a bearer token when `KF_JIRA_USER` is unset.
 
+Searches request `fields=*all`, so issue descriptions and custom text fields are scanned on both Cloud and Server/Data Center. Jira Cloud's search endpoint returns only `id`, `key`, `summary`, and `status` when `fields` is left unset, which would silently exclude descriptions from the scan.
+
 ---
 
 ## Confluence

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1338,7 +1338,7 @@ KF_CONFLUENCE_USER="user@example.com" KF_CONFLUENCE_TOKEN="token" \
     --max-results 500
 ```
 
-Use the base URL of your Confluence site for `--url`. Kingfisher automatically adds `/rest/api` to the end, so `https://example.com/wiki` and `https://example.com` both work depending on your server configuration. For Confluence Cloud, include the `/wiki` path segment Atlassian adds to Cloud sites, e.g. `--url https://example.atlassian.net/wiki`, and set `KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API tokens require Basic auth, not a bearer token. Kingfisher paginates results by following the server-issued `next` link rather than an offset, since Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
+Use the base URL of your Confluence site for `--url`. Kingfisher automatically adds `/rest/api` to the end, so `https://example.com/wiki` and `https://example.com` both work depending on your server configuration. For Confluence Cloud, pass the site URL as-is (`--url https://example.atlassian.net`): Cloud serves its API under a `/wiki` context path, and Kingfisher adds that segment for `*.atlassian.net` hosts, so both that form and the explicit `https://example.atlassian.net/wiki` work. Also set `KF_CONFLUENCE_USER` to your Cloud account email — Confluence Cloud API tokens require Basic auth, not a bearer token. Kingfisher paginates results by following the server-issued `next` link rather than an offset, since Confluence Cloud removed offset-based (`start`) pagination for this endpoint.
 
 Generate a personal access token and set it in the `KF_CONFLUENCE_TOKEN` environment variable. By default, Kingfisher sends the token as a bearer token in the `Authorization` header.
 

--- a/src/cli/commands/scan.rs
+++ b/src/cli/commands/scan.rs
@@ -30,6 +30,11 @@ use crate::{
     rules::rule::Confidence,
 };
 
+/// Sentinel `max_results` meaning "keep paging while the provider returns
+/// results", set by the `--all` flag. Provider fetch loops stop on the last
+/// page or an empty page rather than on this bound.
+pub const UNLIMITED_RESULTS: usize = usize::MAX;
+
 /// Determine the default number of parallel scan jobs.
 ///
 /// * Target = `available_parallelism * 2`.
@@ -657,7 +662,8 @@ impl ScanCommandArgs {
                 ScanInputCommand::Jira(args) => {
                     scan_args.input_specifier_args.jira_url = Some(args.url);
                     scan_args.input_specifier_args.jql = Some(args.jql);
-                    scan_args.input_specifier_args.max_results = args.max_results;
+                    scan_args.input_specifier_args.max_results =
+                        if args.all { UNLIMITED_RESULTS } else { args.max_results };
                     scan_args.input_specifier_args.jira_include_comments = args.include_comments;
                     scan_args.input_specifier_args.jira_include_changelog = args.include_changelog;
                     None
@@ -665,7 +671,8 @@ impl ScanCommandArgs {
                 ScanInputCommand::Confluence(args) => {
                     scan_args.input_specifier_args.confluence_url = Some(args.url);
                     scan_args.input_specifier_args.cql = Some(args.cql);
-                    scan_args.input_specifier_args.max_results = args.max_results;
+                    scan_args.input_specifier_args.max_results =
+                        if args.all { UNLIMITED_RESULTS } else { args.max_results };
                     None
                 }
                 ScanInputCommand::Postman(args) => {
@@ -1043,6 +1050,10 @@ pub struct JiraScanArgs {
     #[arg(long = "max-results", default_value_t = 100)]
     pub max_results: usize,
 
+    /// Fetch every issue matching the JQL query, ignoring `--max-results`
+    #[arg(long = "all", conflicts_with = "max_results")]
+    pub all: bool,
+
     /// Include Jira issue comments in the scan
     #[arg(long = "include-comments", default_value_t = false)]
     pub include_comments: bool,
@@ -1065,6 +1076,10 @@ pub struct ConfluenceScanArgs {
     /// Maximum number of results to fetch
     #[arg(long = "max-results", default_value_t = 100)]
     pub max_results: usize,
+
+    /// Fetch every page matching the CQL query, ignoring `--max-results`
+    #[arg(long = "all", conflicts_with = "max_results")]
+    pub all: bool,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/confluence.rs
+++ b/src/confluence.rs
@@ -1,8 +1,11 @@
 use anyhow::{Context, Result, bail};
 use reqwest::{Client, header};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 use url::Url;
+
+/// Number of results requested per page; Confluence caps this at 100.
+const CONFLUENCE_PAGE_SIZE: usize = 100;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ConfluencePage {
@@ -43,6 +46,47 @@ struct ConfluenceResultLinks {
     next: Option<String>,
 }
 
+/// Builds the request URL for the next page from a server-issued `_links.next`.
+///
+/// Confluence Cloud returns `next` as a root-relative path that omits the
+/// `/wiki` context path (e.g. `/rest/api/content/search?…&cursor=…`), so
+/// resolving it against the configured site URL would silently drop `/wiki`.
+/// Only the query string is taken from `next` — it carries the pagination
+/// state, `cursor` on Cloud and `start` on Server/Data Center — and it is
+/// re-anchored onto the API URL already known to be correct.
+fn next_page_url(api_url: &Url, next: &str, cql: &str, limit: usize) -> Option<Url> {
+    let query = next.split_once('?').map(|(_, query)| query)?;
+
+    let mut url = api_url.clone();
+    url.set_query(Some(query));
+
+    let present: HashSet<String> = url.query_pairs().map(|(key, _)| key.into_owned()).collect();
+
+    // Only follow links that actually advance the cursor; a `next` without
+    // pagination state would re-request the first page forever.
+    if !present.contains("cursor") && !present.contains("start") {
+        return None;
+    }
+
+    // Confluence does not always echo every request parameter back in `next`.
+    // Dropping `expand=body.storage` would leave page bodies empty and
+    // silently hide secrets on every page after the first.
+    {
+        let mut pairs = url.query_pairs_mut();
+        if !present.contains("cql") {
+            pairs.append_pair("cql", cql);
+        }
+        if !present.contains("limit") {
+            pairs.append_pair("limit", &limit.to_string());
+        }
+        if !present.contains("expand") {
+            pairs.append_pair("expand", "body.storage");
+        }
+    }
+
+    Some(url)
+}
+
 pub async fn search_pages(
     confluence_url: Url,
     cql: &str,
@@ -65,7 +109,8 @@ pub async fn search_pages(
         .context("Failed to build HTTP client")?;
 
     let base = confluence_url.as_str().trim_end_matches('/');
-    let api_base = format!("{}/rest/api/content/search", base);
+    let api_url = Url::parse(&format!("{}/rest/api/content/search", base))?;
+    let limit = std::cmp::min(CONFLUENCE_PAGE_SIZE, max_results);
 
     let mut pages = Vec::new();
 
@@ -75,8 +120,7 @@ pub async fn search_pages(
     let mut next_url = if max_results == 0 {
         None
     } else {
-        let mut url = Url::parse(&api_base)?;
-        let limit = std::cmp::min(100, max_results);
+        let mut url = api_url.clone();
         url.query_pairs_mut()
             .append_pair("cql", cql)
             .append_pair("limit", &limit.to_string())
@@ -116,70 +160,136 @@ pub async fn search_pages(
 
         let body: ConfluenceSearchResponse =
             resp.json().await.context("Failed to parse Confluence response")?;
+        let received = body.results.len();
         for p in body.results {
             pages.push(p);
             if pages.len() >= max_results {
                 break;
             }
         }
-        if pages.len() >= max_results {
+
+        // Stopping on an empty page keeps the loop bounded: every remaining
+        // iteration adds at least one page and therefore makes progress toward
+        // `max_results`. Confluence Cloud can hand back an empty result set
+        // alongside a `next` link, which would otherwise spin forever.
+        if pages.len() >= max_results || received == 0 {
             break;
         }
-        // Confluence Cloud's `_links.next` is root-relative and omits the
-        // `/wiki` context path (e.g. `/rest/api/content/search?...&cursor=…`),
-        // so resolving it against `confluence_url` would silently drop
-        // `/wiki`. Keep our own known-correct API base and just swap in the
-        // cursor query string the server gave us.
-        next_url = body.links.next.as_deref().and_then(|next| {
-            let query = next.split_once('?').map(|(_, query)| query)?;
-            let mut url = Url::parse(&api_base).ok()?;
-            url.set_query(Some(query));
-            Some(url)
-        });
+
+        next_url =
+            body.links.next.as_deref().and_then(|next| next_page_url(&api_url, next, cql, limit));
     }
     Ok(pages)
 }
 
+pub async fn download_pages_to_dir(
+    confluence_url: Url,
+    cql: &str,
+    max_results: usize,
+    ignore_certs: bool,
+    output_dir: &PathBuf,
+) -> Result<Vec<(PathBuf, String)>> {
+    std::fs::create_dir_all(output_dir)?;
+    let pages = search_pages(confluence_url.clone(), cql, max_results, ignore_certs).await?;
+    let mut paths = Vec::new();
+    let base = confluence_url.as_str().trim_end_matches('/');
+    let web_base = base.to_string();
+    for page in pages {
+        let file = output_dir.join(format!("{}.json", page.id));
+        std::fs::write(&file, serde_json::to_vec(&page)?)?;
+        let link = format!("{}{}", web_base, page.links.webui);
+        paths.push((file, link));
+    }
+    Ok(paths)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::search_pages;
+    use super::{next_page_url, search_pages};
     use serde_json::json;
-    use std::ffi::OsString;
-    use tokio::sync::Mutex;
     use url::Url;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{method, path, query_param, query_param_is_missing},
     };
 
-    static CONFLUENCE_ENV: Mutex<()> = Mutex::const_new(());
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<OsString>,
+    /// Runs `future` with Confluence bearer-token credentials in the
+    /// environment, so the test does not depend on the developer's own shell.
+    async fn with_confluence_token<T>(future: impl std::future::Future<Output = T>) -> T {
+        temp_env::async_with_vars(
+            [("KF_CONFLUENCE_TOKEN", Some("test-token")), ("KF_CONFLUENCE_USER", None)],
+            future,
+        )
+        .await
     }
 
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
-        }
-
-        fn unset(key: &'static str) -> Self {
-            let previous = std::env::var_os(key);
-            unsafe { std::env::remove_var(key) };
-            Self { key, previous }
-        }
+    fn api_url() -> Url {
+        Url::parse("https://example.atlassian.net/wiki/rest/api/content/search").expect("API URL")
     }
 
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => unsafe { std::env::set_var(self.key, value) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
+    #[test]
+    fn next_page_url_keeps_the_wiki_context_path() {
+        // Confluence Cloud returns `next` without the `/wiki` prefix even
+        // though the request must carry it.
+        let next = next_page_url(
+            &api_url(),
+            "/rest/api/content/search?cql=label+%3D+secret&cursor=abc123&limit=25&expand=body.storage",
+            "label = secret",
+            25,
+        )
+        .expect("next URL should be built");
+
+        assert_eq!(next.path(), "/wiki/rest/api/content/search");
+        assert_eq!(next.host_str(), Some("example.atlassian.net"));
+        assert!(next.query().expect("query").contains("cursor=abc123"));
+    }
+
+    #[test]
+    fn next_page_url_restores_parameters_the_server_dropped() {
+        // Atlassian's own documented `next` example omits `expand`; losing it
+        // would leave page bodies empty and hide secrets after page one.
+        let next = next_page_url(
+            &api_url(),
+            "/rest/api/content/search?limit=25&cursor=abc123",
+            "label = secret",
+            25,
+        )
+        .expect("next URL should be built");
+
+        let pairs: Vec<(String, String)> =
+            next.query_pairs().map(|(k, v)| (k.into_owned(), v.into_owned())).collect();
+        assert!(pairs.contains(&("expand".to_string(), "body.storage".to_string())));
+        assert!(pairs.contains(&("cql".to_string(), "label = secret".to_string())));
+        assert!(pairs.contains(&("cursor".to_string(), "abc123".to_string())));
+        // Whatever the server already supplied is left untouched.
+        assert_eq!(pairs.iter().filter(|(k, _)| k == "limit").count(), 1);
+    }
+
+    #[test]
+    fn next_page_url_accepts_server_data_center_offset_links() {
+        let next = next_page_url(
+            &api_url(),
+            "/rest/api/content/search?cql=label+%3D+secret&start=25&limit=25",
+            "label = secret",
+            25,
+        )
+        .expect("next URL should be built");
+
+        assert!(next.query().expect("query").contains("start=25"));
+    }
+
+    #[test]
+    fn next_page_url_rejects_links_without_pagination_state() {
+        // A `next` that carries neither `cursor` nor `start` would re-request
+        // the first page forever.
+        assert!(
+            next_page_url(&api_url(), "/rest/api/content/search?cql=x", "x", 25).is_none(),
+            "links without pagination state must not be followed"
+        );
+        assert!(
+            next_page_url(&api_url(), "/rest/api/content/search", "x", 25).is_none(),
+            "links without a query string must not be followed"
+        );
     }
 
     #[tokio::test]
@@ -187,10 +297,6 @@ mod tests {
         if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
             return;
         }
-        let _lock = CONFLUENCE_ENV.lock().await;
-        let _token = EnvVarGuard::set("KF_CONFLUENCE_TOKEN", "test-token");
-        let _user = EnvVarGuard::unset("KF_CONFLUENCE_USER");
-
         let server = MockServer::start().await;
 
         // Confluence Cloud paginates this endpoint via a cursor embedded in
@@ -223,9 +329,10 @@ mod tests {
             .await;
 
         let confluence_url = Url::parse(&server.uri()).expect("server URL");
-        let pages = search_pages(confluence_url, "label = secret", 10, false)
-            .await
-            .expect("pages should be fetched");
+        let pages =
+            with_confluence_token(search_pages(confluence_url, "label = secret", 10, false))
+                .await
+                .expect("pages should be fetched");
 
         assert_eq!(pages.len(), 2);
         assert_eq!(pages[0].id, "1");
@@ -237,17 +344,11 @@ mod tests {
         if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
             return;
         }
-        let _lock = CONFLUENCE_ENV.lock().await;
-        let _token = EnvVarGuard::set("KF_CONFLUENCE_TOKEN", "test-token");
-        let _user = EnvVarGuard::unset("KF_CONFLUENCE_USER");
-
         let server = MockServer::start().await;
 
         // Real Confluence Cloud responses return `_links.next` as root-relative
-        // and *without* the `/wiki` context path Cloud sites require, e.g.
-        // `/rest/api/content/search?...&cursor=...` even though the request
-        // was made against `/wiki/rest/api/content/search`. Kingfisher must
-        // not lose the `/wiki` segment when following it.
+        // and *without* the `/wiki` context path Cloud sites require, even
+        // though the request went to `/wiki/rest/api/content/search`.
         Mock::given(method("GET"))
             .and(path("/wiki/rest/api/content/search"))
             .and(query_param_is_missing("cursor"))
@@ -275,9 +376,10 @@ mod tests {
             .await;
 
         let confluence_url = Url::parse(&format!("{}/wiki", server.uri())).expect("server URL");
-        let pages = search_pages(confluence_url, "label = secret", 10, false)
-            .await
-            .expect("pages should be fetched");
+        let pages =
+            with_confluence_token(search_pages(confluence_url, "label = secret", 10, false))
+                .await
+                .expect("pages should be fetched");
 
         assert_eq!(pages.len(), 2);
         assert_eq!(pages[0].id, "1");
@@ -285,14 +387,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_pages_stops_on_an_empty_page_that_still_advertises_next() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/content/search"))
+            .and(query_param_is_missing("cursor"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {"id": "1", "title": "first", "_links": {"webui": "/pages/1"}}
+                ],
+                "_links": {"next": "/rest/api/content/search?cursor=abc123"}
+            })))
+            .mount(&server)
+            .await;
+
+        // Confluence Cloud can return an empty result set together with a
+        // `next` link; following it forever would hang the scan. The cursor
+        // never changes, so the mock is only allowed to be hit once.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/content/search"))
+            .and(query_param("cursor", "abc123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [],
+                "_links": {"next": "/rest/api/content/search?cursor=abc123"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let confluence_url = Url::parse(&server.uri()).expect("server URL");
+        let pages =
+            with_confluence_token(search_pages(confluence_url, "label = secret", 50, false))
+                .await
+                .expect("pages should be fetched");
+
+        assert_eq!(pages.len(), 1);
+    }
+
+    #[tokio::test]
     async fn search_pages_stops_once_max_results_reached_without_following_next() {
         if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
             return;
         }
-        let _lock = CONFLUENCE_ENV.lock().await;
-        let _token = EnvVarGuard::set("KF_CONFLUENCE_TOKEN", "test-token");
-        let _user = EnvVarGuard::unset("KF_CONFLUENCE_USER");
-
         let server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -311,32 +451,11 @@ mod tests {
             .await;
 
         let confluence_url = Url::parse(&server.uri()).expect("server URL");
-        let pages = search_pages(confluence_url, "label = secret", 1, false)
+        let pages = with_confluence_token(search_pages(confluence_url, "label = secret", 1, false))
             .await
             .expect("pages should be fetched");
 
         assert_eq!(pages.len(), 1);
         assert_eq!(pages[0].id, "1");
     }
-}
-
-pub async fn download_pages_to_dir(
-    confluence_url: Url,
-    cql: &str,
-    max_results: usize,
-    ignore_certs: bool,
-    output_dir: &PathBuf,
-) -> Result<Vec<(PathBuf, String)>> {
-    std::fs::create_dir_all(output_dir)?;
-    let pages = search_pages(confluence_url.clone(), cql, max_results, ignore_certs).await?;
-    let mut paths = Vec::new();
-    let base = confluence_url.as_str().trim_end_matches('/');
-    let web_base = base.to_string();
-    for page in pages {
-        let file = output_dir.join(format!("{}.json", page.id));
-        std::fs::write(&file, serde_json::to_vec(&page)?)?;
-        let link = format!("{}{}", web_base, page.links.webui);
-        paths.push((file, link));
-    }
-    Ok(paths)
 }

--- a/src/confluence.rs
+++ b/src/confluence.rs
@@ -46,6 +46,28 @@ struct ConfluenceResultLinks {
     next: Option<String>,
 }
 
+/// Adds Confluence Cloud's `/wiki` context path when it is missing.
+///
+/// Cloud serves the REST API under `<site>.atlassian.net/wiki/rest/api/...`,
+/// while Server/Data Center serves it at the site root or a custom context
+/// path. Passing the bare Cloud site URL otherwise fails with a 404 whose body
+/// reads `No endpoint GET /rest/api/content/search`, which gives no hint that a
+/// path segment is missing.
+///
+/// Only a root path is rewritten: an explicit path is left alone rather than
+/// second-guessed, so a deliberate context path still works.
+fn normalize_confluence_base(confluence_url: &Url) -> Url {
+    let is_cloud = confluence_url.host_str().is_some_and(|host| host.ends_with(".atlassian.net"));
+    let path_is_root = matches!(confluence_url.path(), "" | "/");
+    if !is_cloud || !path_is_root {
+        return confluence_url.clone();
+    }
+
+    let mut url = confluence_url.clone();
+    url.set_path("/wiki");
+    url
+}
+
 /// Builds the request URL for the next page from a server-issued `_links.next`.
 ///
 /// Confluence Cloud returns `next` as a root-relative path that omits the
@@ -108,7 +130,8 @@ pub async fn search_pages(
         .build()
         .context("Failed to build HTTP client")?;
 
-    let base = confluence_url.as_str().trim_end_matches('/');
+    let site_url = normalize_confluence_base(&confluence_url);
+    let base = site_url.as_str().trim_end_matches('/');
     let api_url = Url::parse(&format!("{}/rest/api/content/search", base))?;
     let limit = std::cmp::min(CONFLUENCE_PAGE_SIZE, max_results);
 
@@ -192,8 +215,10 @@ pub async fn download_pages_to_dir(
     std::fs::create_dir_all(output_dir)?;
     let pages = search_pages(confluence_url.clone(), cql, max_results, ignore_certs).await?;
     let mut paths = Vec::new();
-    let base = confluence_url.as_str().trim_end_matches('/');
-    let web_base = base.to_string();
+    // `webui` links are relative to the same context path the API lives under,
+    // so they need the identical normalization.
+    let site_url = normalize_confluence_base(&confluence_url);
+    let web_base = site_url.as_str().trim_end_matches('/').to_string();
     for page in pages {
         let file = output_dir.join(format!("{}.json", page.id));
         std::fs::write(&file, serde_json::to_vec(&page)?)?;
@@ -205,7 +230,7 @@ pub async fn download_pages_to_dir(
 
 #[cfg(test)]
 mod tests {
-    use super::{next_page_url, search_pages};
+    use super::{next_page_url, normalize_confluence_base, search_pages};
     use serde_json::json;
     use url::Url;
     use wiremock::{
@@ -225,6 +250,44 @@ mod tests {
 
     fn api_url() -> Url {
         Url::parse("https://example.atlassian.net/wiki/rest/api/content/search").expect("API URL")
+    }
+
+    #[test]
+    fn normalize_confluence_base_adds_the_cloud_wiki_context_path() {
+        // The reported failure: a bare Cloud site URL 404s with
+        // "No endpoint GET /rest/api/content/search".
+        let normalized =
+            normalize_confluence_base(&Url::parse("https://example.atlassian.net").unwrap());
+        assert_eq!(normalized.as_str(), "https://example.atlassian.net/wiki");
+
+        let with_slash =
+            normalize_confluence_base(&Url::parse("https://example.atlassian.net/").unwrap());
+        assert_eq!(with_slash.as_str(), "https://example.atlassian.net/wiki");
+    }
+
+    #[test]
+    fn normalize_confluence_base_does_not_double_the_wiki_segment() {
+        let normalized =
+            normalize_confluence_base(&Url::parse("https://example.atlassian.net/wiki").unwrap());
+        assert_eq!(normalized.as_str(), "https://example.atlassian.net/wiki");
+    }
+
+    #[test]
+    fn normalize_confluence_base_leaves_self_hosted_and_explicit_paths_alone() {
+        // Server/Data Center serves the API at the site root...
+        let server =
+            normalize_confluence_base(&Url::parse("https://confluence.example.com").unwrap());
+        assert_eq!(server.as_str(), "https://confluence.example.com/");
+
+        // ...or under a custom context path, which must not be rewritten.
+        let context =
+            normalize_confluence_base(&Url::parse("https://example.com/confluence").unwrap());
+        assert_eq!(context.as_str(), "https://example.com/confluence");
+
+        // An explicit path on a Cloud host is deliberate; leave it be.
+        let explicit =
+            normalize_confluence_base(&Url::parse("https://example.atlassian.net/other").unwrap());
+        assert_eq!(explicit.as_str(), "https://example.atlassian.net/other");
     }
 
     #[test]

--- a/src/confluence.rs
+++ b/src/confluence.rs
@@ -125,7 +125,17 @@ pub async fn search_pages(
         if pages.len() >= max_results {
             break;
         }
-        next_url = body.links.next.as_deref().and_then(|next| confluence_url.join(next).ok());
+        // Confluence Cloud's `_links.next` is root-relative and omits the
+        // `/wiki` context path (e.g. `/rest/api/content/search?...&cursor=…`),
+        // so resolving it against `confluence_url` would silently drop
+        // `/wiki`. Keep our own known-correct API base and just swap in the
+        // cursor query string the server gave us.
+        next_url = body.links.next.as_deref().and_then(|next| {
+            let query = next.split_once('?').map(|(_, query)| query)?;
+            let mut url = Url::parse(&api_base).ok()?;
+            url.set_query(Some(query));
+            Some(url)
+        });
     }
     Ok(pages)
 }
@@ -213,6 +223,58 @@ mod tests {
             .await;
 
         let confluence_url = Url::parse(&server.uri()).expect("server URL");
+        let pages = search_pages(confluence_url, "label = secret", 10, false)
+            .await
+            .expect("pages should be fetched");
+
+        assert_eq!(pages.len(), 2);
+        assert_eq!(pages[0].id, "1");
+        assert_eq!(pages[1].id, "2");
+    }
+
+    #[tokio::test]
+    async fn search_pages_preserves_wiki_context_path_on_cloud() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let _lock = CONFLUENCE_ENV.lock().await;
+        let _token = EnvVarGuard::set("KF_CONFLUENCE_TOKEN", "test-token");
+        let _user = EnvVarGuard::unset("KF_CONFLUENCE_USER");
+
+        let server = MockServer::start().await;
+
+        // Real Confluence Cloud responses return `_links.next` as root-relative
+        // and *without* the `/wiki` context path Cloud sites require, e.g.
+        // `/rest/api/content/search?...&cursor=...` even though the request
+        // was made against `/wiki/rest/api/content/search`. Kingfisher must
+        // not lose the `/wiki` segment when following it.
+        Mock::given(method("GET"))
+            .and(path("/wiki/rest/api/content/search"))
+            .and(query_param_is_missing("cursor"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {"id": "1", "title": "first", "_links": {"webui": "/pages/1"}}
+                ],
+                "_links": {
+                    "next": "/rest/api/content/search?cql=label+%3D+secret&cursor=abc123&limit=1&expand=body.storage"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/wiki/rest/api/content/search"))
+            .and(query_param("cursor", "abc123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {"id": "2", "title": "second", "_links": {"webui": "/pages/2"}}
+                ],
+                "_links": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let confluence_url = Url::parse(&format!("{}/wiki", server.uri())).expect("server URL");
         let pages = search_pages(confluence_url, "label = secret", 10, false)
             .await
             .expect("pages should be fetched");

--- a/src/confluence.rs
+++ b/src/confluence.rs
@@ -67,19 +67,25 @@ pub async fn search_pages(
     let base = confluence_url.as_str().trim_end_matches('/');
     let api_base = format!("{}/rest/api/content/search", base);
 
-    let api_url = Url::parse(&api_base)?;
     let mut pages = Vec::new();
-    let mut start = 0usize;
 
-    while pages.len() < max_results {
-        let limit = std::cmp::min(100, max_results - pages.len());
-        let url = api_url.clone();
-        let req = client.get(url).query(&[
-            ("cql", cql),
-            ("limit", &limit.to_string()),
-            ("start", &start.to_string()),
-            ("expand", "body.storage"),
-        ]);
+    // Confluence Cloud removed offset-based `start` pagination for this
+    // endpoint in 2020 in favor of a server-issued cursor; Server/Data Center
+    // still returns a `_links.next` URL too, so following it works for both.
+    let mut next_url = if max_results == 0 {
+        None
+    } else {
+        let mut url = Url::parse(&api_base)?;
+        let limit = std::cmp::min(100, max_results);
+        url.query_pairs_mut()
+            .append_pair("cql", cql)
+            .append_pair("limit", &limit.to_string())
+            .append_pair("expand", "body.storage");
+        Some(url)
+    };
+
+    while let Some(url) = next_url.take() {
+        let req = client.get(url);
         let req = if let Some(user) = &user {
             req.basic_auth(user, Some(&token))
         } else {
@@ -116,12 +122,140 @@ pub async fn search_pages(
                 break;
             }
         }
-        if pages.len() >= max_results || body.links.next.is_none() {
+        if pages.len() >= max_results {
             break;
         }
-        start += limit;
+        next_url = body.links.next.as_deref().and_then(|next| confluence_url.join(next).ok());
     }
     Ok(pages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::search_pages;
+    use serde_json::json;
+    use std::ffi::OsString;
+    use tokio::sync::Mutex;
+    use url::Url;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path, query_param, query_param_is_missing},
+    };
+
+    static CONFLUENCE_ENV: Mutex<()> = Mutex::const_new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::remove_var(key) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn search_pages_follows_cursor_based_next_link() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let _lock = CONFLUENCE_ENV.lock().await;
+        let _token = EnvVarGuard::set("KF_CONFLUENCE_TOKEN", "test-token");
+        let _user = EnvVarGuard::unset("KF_CONFLUENCE_USER");
+
+        let server = MockServer::start().await;
+
+        // Confluence Cloud paginates this endpoint via a cursor embedded in
+        // `_links.next`, not via a repeated/incrementing `start` parameter.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/content/search"))
+            .and(query_param("cql", "label = secret"))
+            .and(query_param_is_missing("cursor"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {"id": "1", "title": "first", "_links": {"webui": "/pages/1"}}
+                ],
+                "_links": {
+                    "next": "/rest/api/content/search?cql=label+%3D+secret&cursor=abc123&limit=1&expand=body.storage"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/content/search"))
+            .and(query_param("cursor", "abc123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {"id": "2", "title": "second", "_links": {"webui": "/pages/2"}}
+                ],
+                "_links": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let confluence_url = Url::parse(&server.uri()).expect("server URL");
+        let pages = search_pages(confluence_url, "label = secret", 10, false)
+            .await
+            .expect("pages should be fetched");
+
+        assert_eq!(pages.len(), 2);
+        assert_eq!(pages[0].id, "1");
+        assert_eq!(pages[1].id, "2");
+    }
+
+    #[tokio::test]
+    async fn search_pages_stops_once_max_results_reached_without_following_next() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let _lock = CONFLUENCE_ENV.lock().await;
+        let _token = EnvVarGuard::set("KF_CONFLUENCE_TOKEN", "test-token");
+        let _user = EnvVarGuard::unset("KF_CONFLUENCE_USER");
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/content/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {"id": "1", "title": "first", "_links": {"webui": "/pages/1"}},
+                    {"id": "2", "title": "second", "_links": {"webui": "/pages/2"}}
+                ],
+                "_links": {
+                    "next": "/rest/api/content/search?cursor=should-not-be-fetched"
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let confluence_url = Url::parse(&server.uri()).expect("server URL");
+        let pages = search_pages(confluence_url, "label = secret", 1, false)
+            .await
+            .expect("pages should be fetched");
+
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].id, "1");
+    }
 }
 
 pub async fn download_pages_to_dir(

--- a/src/confluence.rs
+++ b/src/confluence.rs
@@ -46,16 +46,10 @@ struct ConfluenceResultLinks {
     next: Option<String>,
 }
 
-/// Adds Confluence Cloud's `/wiki` context path when it is missing.
-///
-/// Cloud serves the REST API under `<site>.atlassian.net/wiki/rest/api/...`,
-/// while Server/Data Center serves it at the site root or a custom context
-/// path. Passing the bare Cloud site URL otherwise fails with a 404 whose body
-/// reads `No endpoint GET /rest/api/content/search`, which gives no hint that a
-/// path segment is missing.
-///
-/// Only a root path is rewritten: an explicit path is left alone rather than
-/// second-guessed, so a deliberate context path still works.
+/// Adds Confluence Cloud's `/wiki` context path, which Server/Data Center does
+/// not use. Without it Cloud answers `404 No endpoint GET
+/// /rest/api/content/search`. Only a root path is rewritten, so a deliberate
+/// context path is left alone.
 fn normalize_confluence_base(confluence_url: &Url) -> Url {
     let is_cloud = confluence_url.host_str().is_some_and(|host| host.ends_with(".atlassian.net"));
     let path_is_root = matches!(confluence_url.path(), "" | "/");
@@ -68,14 +62,9 @@ fn normalize_confluence_base(confluence_url: &Url) -> Url {
     url
 }
 
-/// Builds the request URL for the next page from a server-issued `_links.next`.
-///
-/// Confluence Cloud returns `next` as a root-relative path that omits the
-/// `/wiki` context path (e.g. `/rest/api/content/search?…&cursor=…`), so
-/// resolving it against the configured site URL would silently drop `/wiki`.
-/// Only the query string is taken from `next` — it carries the pagination
-/// state, `cursor` on Cloud and `start` on Server/Data Center — and it is
-/// re-anchored onto the API URL already known to be correct.
+/// Re-anchors the pagination state from `_links.next` onto our own API URL.
+/// Cloud returns `next` without the `/wiki` prefix, so resolving it against the
+/// site URL would drop that segment.
 fn next_page_url(api_url: &Url, next: &str, cql: &str, limit: usize) -> Option<Url> {
     let query = next.split_once('?').map(|(_, query)| query)?;
 
@@ -84,15 +73,13 @@ fn next_page_url(api_url: &Url, next: &str, cql: &str, limit: usize) -> Option<U
 
     let present: HashSet<String> = url.query_pairs().map(|(key, _)| key.into_owned()).collect();
 
-    // Only follow links that actually advance the cursor; a `next` without
-    // pagination state would re-request the first page forever.
+    // A `next` without pagination state would re-request the first page forever.
     if !present.contains("cursor") && !present.contains("start") {
         return None;
     }
 
-    // Confluence does not always echo every request parameter back in `next`.
-    // Dropping `expand=body.storage` would leave page bodies empty and
-    // silently hide secrets on every page after the first.
+    // `next` does not always echo every parameter back; dropping
+    // `expand=body.storage` would blank page bodies and hide secrets.
     {
         let mut pairs = url.query_pairs_mut();
         if !present.contains("cql") {
@@ -137,9 +124,8 @@ pub async fn search_pages(
 
     let mut pages = Vec::new();
 
-    // Confluence Cloud removed offset-based `start` pagination for this
-    // endpoint in 2020 in favor of a server-issued cursor; Server/Data Center
-    // still returns a `_links.next` URL too, so following it works for both.
+    // Cloud dropped offset pagination here in 2020; following `_links.next`
+    // works for both deployments.
     let mut next_url = if max_results == 0 {
         None
     } else {
@@ -191,10 +177,8 @@ pub async fn search_pages(
             }
         }
 
-        // Stopping on an empty page keeps the loop bounded: every remaining
-        // iteration adds at least one page and therefore makes progress toward
-        // `max_results`. Confluence Cloud can hand back an empty result set
-        // alongside a `next` link, which would otherwise spin forever.
+        // Cloud can return an empty page alongside a `next` link; stopping here
+        // is what keeps the loop bounded.
         if pages.len() >= max_results || received == 0 {
             break;
         }
@@ -215,8 +199,7 @@ pub async fn download_pages_to_dir(
     std::fs::create_dir_all(output_dir)?;
     let pages = search_pages(confluence_url.clone(), cql, max_results, ignore_certs).await?;
     let mut paths = Vec::new();
-    // `webui` links are relative to the same context path the API lives under,
-    // so they need the identical normalization.
+    // `webui` is relative to the same context path as the API.
     let site_url = normalize_confluence_base(&confluence_url);
     let web_base = site_url.as_str().trim_end_matches('/').to_string();
     for page in pages {
@@ -238,8 +221,6 @@ mod tests {
         matchers::{method, path, query_param, query_param_is_missing},
     };
 
-    /// Runs `future` with Confluence bearer-token credentials in the
-    /// environment, so the test does not depend on the developer's own shell.
     async fn with_confluence_token<T>(future: impl std::future::Future<Output = T>) -> T {
         temp_env::async_with_vars(
             [("KF_CONFLUENCE_TOKEN", Some("test-token")), ("KF_CONFLUENCE_USER", None)],
@@ -254,8 +235,6 @@ mod tests {
 
     #[test]
     fn normalize_confluence_base_adds_the_cloud_wiki_context_path() {
-        // The reported failure: a bare Cloud site URL 404s with
-        // "No endpoint GET /rest/api/content/search".
         let normalized =
             normalize_confluence_base(&Url::parse("https://example.atlassian.net").unwrap());
         assert_eq!(normalized.as_str(), "https://example.atlassian.net/wiki");
@@ -274,17 +253,14 @@ mod tests {
 
     #[test]
     fn normalize_confluence_base_leaves_self_hosted_and_explicit_paths_alone() {
-        // Server/Data Center serves the API at the site root...
         let server =
             normalize_confluence_base(&Url::parse("https://confluence.example.com").unwrap());
         assert_eq!(server.as_str(), "https://confluence.example.com/");
 
-        // ...or under a custom context path, which must not be rewritten.
         let context =
             normalize_confluence_base(&Url::parse("https://example.com/confluence").unwrap());
         assert_eq!(context.as_str(), "https://example.com/confluence");
 
-        // An explicit path on a Cloud host is deliberate; leave it be.
         let explicit =
             normalize_confluence_base(&Url::parse("https://example.atlassian.net/other").unwrap());
         assert_eq!(explicit.as_str(), "https://example.atlassian.net/other");
@@ -292,8 +268,6 @@ mod tests {
 
     #[test]
     fn next_page_url_keeps_the_wiki_context_path() {
-        // Confluence Cloud returns `next` without the `/wiki` prefix even
-        // though the request must carry it.
         let next = next_page_url(
             &api_url(),
             "/rest/api/content/search?cql=label+%3D+secret&cursor=abc123&limit=25&expand=body.storage",
@@ -309,8 +283,7 @@ mod tests {
 
     #[test]
     fn next_page_url_restores_parameters_the_server_dropped() {
-        // Atlassian's own documented `next` example omits `expand`; losing it
-        // would leave page bodies empty and hide secrets after page one.
+        // Atlassian's own documented `next` example omits `expand`.
         let next = next_page_url(
             &api_url(),
             "/rest/api/content/search?limit=25&cursor=abc123",
@@ -324,7 +297,6 @@ mod tests {
         assert!(pairs.contains(&("expand".to_string(), "body.storage".to_string())));
         assert!(pairs.contains(&("cql".to_string(), "label = secret".to_string())));
         assert!(pairs.contains(&("cursor".to_string(), "abc123".to_string())));
-        // Whatever the server already supplied is left untouched.
         assert_eq!(pairs.iter().filter(|(k, _)| k == "limit").count(), 1);
     }
 
@@ -343,8 +315,6 @@ mod tests {
 
     #[test]
     fn next_page_url_rejects_links_without_pagination_state() {
-        // A `next` that carries neither `cursor` nor `start` would re-request
-        // the first page forever.
         assert!(
             next_page_url(&api_url(), "/rest/api/content/search?cql=x", "x", 25).is_none(),
             "links without pagination state must not be followed"
@@ -362,8 +332,6 @@ mod tests {
         }
         let server = MockServer::start().await;
 
-        // Confluence Cloud paginates this endpoint via a cursor embedded in
-        // `_links.next`, not via a repeated/incrementing `start` parameter.
         Mock::given(method("GET"))
             .and(path("/rest/api/content/search"))
             .and(query_param("cql", "label = secret"))
@@ -409,9 +377,7 @@ mod tests {
         }
         let server = MockServer::start().await;
 
-        // Real Confluence Cloud responses return `_links.next` as root-relative
-        // and *without* the `/wiki` context path Cloud sites require, even
-        // though the request went to `/wiki/rest/api/content/search`.
+        // Cloud returns `next` without the `/wiki` the request needs.
         Mock::given(method("GET"))
             .and(path("/wiki/rest/api/content/search"))
             .and(query_param_is_missing("cursor"))
@@ -468,9 +434,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        // Confluence Cloud can return an empty result set together with a
-        // `next` link; following it forever would hang the scan. The cursor
-        // never changes, so the mock is only allowed to be hit once.
+        // The cursor never changes, so the mock may only be hit once.
         Mock::given(method("GET"))
             .and(path("/rest/api/content/search"))
             .and(query_param("cursor", "abc123"))

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use gouqi::{Credentials, SearchOptions, r#async::Jira};
 use reqwest_0_12::Client;
 use std::path::{Path, PathBuf};
@@ -258,18 +258,35 @@ fn build_http_client(ignore_certs: bool) -> Result<Client> {
         .context("Failed to build HTTP client")
 }
 
+// Jira Cloud (*.atlassian.net) API tokens must be sent as Basic auth with the
+// account email as the username; Bearer is reserved for OAuth 2.0 access
+// tokens. Jira Server/Data Center Personal Access Tokens keep working as
+// Bearer when KF_JIRA_USER is unset.
+fn jira_credentials_env() -> Result<(Option<String>, Option<String>)> {
+    let user = std::env::var("KF_JIRA_USER").ok();
+    if let Some(ref u) = user
+        && !u.contains('@')
+    {
+        bail!("KF_JIRA_USER must be an email address");
+    }
+    let token = std::env::var("KF_JIRA_TOKEN").ok();
+    Ok((user, token))
+}
+
+fn jira_credentials() -> Result<Credentials> {
+    let (user, token) = jira_credentials_env()?;
+    Ok(match (user, token) {
+        (Some(user), Some(token)) => Credentials::Basic(user, token),
+        (None, Some(token)) => Credentials::Bearer(token),
+        _ => Credentials::Anonymous,
+    })
+}
+
 fn build_jira_client(jira_url: &Url, ignore_certs: bool) -> Result<Jira> {
     let base = jira_url.as_str().trim_end_matches('/');
     let client = build_http_client(ignore_certs)?;
-    let credentials = match std::env::var("KF_JIRA_TOKEN") {
-        Ok(token) => Credentials::Bearer(token),
-        Err(_) => Credentials::Anonymous,
-    };
+    let credentials = jira_credentials()?;
     Ok(Jira::from_client(base.to_string(), credentials, client)?)
-}
-
-fn jira_auth_header() -> Option<String> {
-    std::env::var("KF_JIRA_TOKEN").ok().map(|token| format!("Bearer {}", token))
 }
 
 fn jira_relative_base_url(jira_url: &Url) -> Url {
@@ -342,6 +359,7 @@ pub async fn fetch_comments(
     }
 
     let client = build_http_client(ignore_certs)?;
+    let (user, token) = jira_credentials_env()?;
     let mut start_at = 0;
     let mut all_comments = Vec::new();
     let base_url = jira_relative_base_url(jira_url);
@@ -353,10 +371,12 @@ pub async fn fetch_comments(
             ))
             .context("Failed to construct Jira comments URL")?;
 
-        let mut request = client.get(url);
-        if let Some(auth) = jira_auth_header() {
-            request = request.header("Authorization", auth);
-        }
+        let request = client.get(url);
+        let request = match (&user, &token) {
+            (Some(user), Some(token)) => request.basic_auth(user, Some(token)),
+            (None, Some(token)) => request.bearer_auth(token),
+            _ => request,
+        };
 
         let response = request.send().await.context("Failed to fetch Jira comments")?;
         let status = response.status();

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use gouqi::{Credentials, SearchOptions, r#async::Jira};
-use reqwest_0_12::Client;
+use reqwest_0_12::{Client, RequestBuilder};
 use std::path::{Path, PathBuf};
 use url::Url;
 
@@ -258,37 +258,60 @@ fn build_http_client(ignore_certs: bool) -> Result<Client> {
         .context("Failed to build HTTP client")
 }
 
-// Jira Cloud (*.atlassian.net) API tokens must be sent as Basic auth with the
-// account email as the username; Bearer is reserved for OAuth 2.0 access
-// tokens. Jira Server/Data Center Personal Access Tokens keep working as
-// Bearer when KF_JIRA_USER is unset.
-fn jira_credentials_env() -> Result<(Option<String>, Option<String>)> {
-    let user = std::env::var("KF_JIRA_USER").ok();
-    if let Some(ref u) = user
-        && !u.contains('@')
-    {
-        bail!("KF_JIRA_USER must be an email address");
-    }
-    let token = std::env::var("KF_JIRA_TOKEN").ok();
-    if user.is_some() && token.is_none() {
-        bail!("KF_JIRA_USER is set but KF_JIRA_TOKEN is not; Jira Cloud Basic auth requires both");
-    }
-    Ok((user, token))
+/// Jira authentication resolved from the environment.
+///
+/// Jira Cloud (*.atlassian.net) API tokens must be sent as Basic auth with the
+/// account email as the username; Bearer is reserved for OAuth 2.0 access
+/// tokens. Jira Server/Data Center Personal Access Tokens keep working as
+/// Bearer when `KF_JIRA_USER` is unset.
+///
+/// The JQL search goes through `gouqi` while comments are fetched directly, so
+/// both paths resolve auth here to keep them from drifting apart.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum JiraAuth {
+    Basic { user: String, token: String },
+    Bearer(String),
+    Anonymous,
 }
 
-fn jira_credentials() -> Result<Credentials> {
-    let (user, token) = jira_credentials_env()?;
-    Ok(match (user, token) {
-        (Some(user), Some(token)) => Credentials::Basic(user, token),
-        (None, Some(token)) => Credentials::Bearer(token),
-        _ => Credentials::Anonymous,
-    })
+impl JiraAuth {
+    fn from_env() -> Result<Self> {
+        match (std::env::var("KF_JIRA_USER").ok(), std::env::var("KF_JIRA_TOKEN").ok()) {
+            (Some(user), Some(token)) => {
+                if !user.contains('@') {
+                    bail!("KF_JIRA_USER must be an email address");
+                }
+                Ok(Self::Basic { user, token })
+            }
+            (Some(_), None) => bail!(
+                "KF_JIRA_USER is set but KF_JIRA_TOKEN is not; Jira Cloud Basic auth requires both"
+            ),
+            (None, Some(token)) => Ok(Self::Bearer(token)),
+            (None, None) => Ok(Self::Anonymous),
+        }
+    }
+
+    fn credentials(self) -> Credentials {
+        match self {
+            Self::Basic { user, token } => Credentials::Basic(user, token),
+            Self::Bearer(token) => Credentials::Bearer(token),
+            Self::Anonymous => Credentials::Anonymous,
+        }
+    }
+
+    fn apply(&self, request: RequestBuilder) -> RequestBuilder {
+        match self {
+            Self::Basic { user, token } => request.basic_auth(user, Some(token)),
+            Self::Bearer(token) => request.bearer_auth(token),
+            Self::Anonymous => request,
+        }
+    }
 }
 
 fn build_jira_client(jira_url: &Url, ignore_certs: bool) -> Result<Jira> {
     let base = jira_url.as_str().trim_end_matches('/');
     let client = build_http_client(ignore_certs)?;
-    let credentials = jira_credentials()?;
+    let credentials = JiraAuth::from_env()?.credentials();
     Ok(Jira::from_client(base.to_string(), credentials, client)?)
 }
 
@@ -362,7 +385,7 @@ pub async fn fetch_comments(
     }
 
     let client = build_http_client(ignore_certs)?;
-    let (user, token) = jira_credentials_env()?;
+    let auth = JiraAuth::from_env()?;
     let mut start_at = 0;
     let mut all_comments = Vec::new();
     let base_url = jira_relative_base_url(jira_url);
@@ -374,12 +397,7 @@ pub async fn fetch_comments(
             ))
             .context("Failed to construct Jira comments URL")?;
 
-        let request = client.get(url);
-        let request = match (&user, &token) {
-            (Some(user), Some(token)) => request.basic_auth(user, Some(token)),
-            (None, Some(token)) => request.bearer_auth(token),
-            _ => request,
-        };
+        let request = auth.apply(client.get(url));
 
         let response = request.send().await.context("Failed to fetch Jira comments")?;
         let status = response.status();
@@ -463,67 +481,83 @@ pub async fn download_issues_to_dir(
 #[cfg(test)]
 mod tests {
     use super::{
-        JIRA_COMMENTS_PAGE_SIZE, extract_adf_text, extract_embedded_comments, fetch_comments,
-        flatten_adf_fields, flatten_comment_bodies, is_adf, jira_credentials_env,
+        JIRA_COMMENTS_PAGE_SIZE, JiraAuth, extract_adf_text, extract_embedded_comments,
+        fetch_comments, flatten_adf_fields, flatten_comment_bodies, is_adf,
     };
     use serde_json::json;
-    use std::ffi::OsString;
-    use std::sync::Mutex;
     use url::Url;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{method, path, query_param},
     };
 
-    static JIRA_ENV: Mutex<()> = Mutex::new(());
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
-        }
-
-        fn unset(key: &'static str) -> Self {
-            let previous = std::env::var_os(key);
-            unsafe { std::env::remove_var(key) };
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => unsafe { std::env::set_var(self.key, value) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
+    /// Runs `future` with Jira credentials cleared, so the test does not depend
+    /// on the developer's own shell (a stray `KF_JIRA_USER` would now be a
+    /// hard error rather than a silent fallback to anonymous).
+    async fn without_jira_credentials<T>(future: impl std::future::Future<Output = T>) -> T {
+        temp_env::async_with_vars([("KF_JIRA_USER", None::<&str>), ("KF_JIRA_TOKEN", None)], future)
+            .await
     }
 
     #[test]
-    fn jira_credentials_env_rejects_user_without_token() {
-        let _lock = JIRA_ENV.lock().unwrap();
-        let _user = EnvVarGuard::set("KF_JIRA_USER", "user@example.com");
-        let _token = EnvVarGuard::unset("KF_JIRA_TOKEN");
-
-        let err = jira_credentials_env().expect_err("should reject user without token");
-        assert!(err.to_string().contains("KF_JIRA_TOKEN"));
+    fn jira_auth_uses_basic_for_cloud_email_and_token() {
+        temp_env::with_vars(
+            [("KF_JIRA_USER", Some("user@example.com")), ("KF_JIRA_TOKEN", Some("test-token"))],
+            || {
+                assert_eq!(
+                    JiraAuth::from_env().expect("should accept email and token"),
+                    JiraAuth::Basic {
+                        user: "user@example.com".to_string(),
+                        token: "test-token".to_string(),
+                    }
+                );
+            },
+        );
     }
 
     #[test]
-    fn jira_credentials_env_accepts_user_and_token() {
-        let _lock = JIRA_ENV.lock().unwrap();
-        let _user = EnvVarGuard::set("KF_JIRA_USER", "user@example.com");
-        let _token = EnvVarGuard::set("KF_JIRA_TOKEN", "test-token");
+    fn jira_auth_uses_bearer_when_user_is_unset() {
+        temp_env::with_vars(
+            [("KF_JIRA_USER", None), ("KF_JIRA_TOKEN", Some("test-token"))],
+            || {
+                assert_eq!(
+                    JiraAuth::from_env().expect("should accept a bare token"),
+                    JiraAuth::Bearer("test-token".to_string())
+                );
+            },
+        );
+    }
 
-        let (user, token) = jira_credentials_env().expect("should accept user and token");
-        assert_eq!(user.as_deref(), Some("user@example.com"));
-        assert_eq!(token.as_deref(), Some("test-token"));
+    #[test]
+    fn jira_auth_rejects_user_without_token() {
+        temp_env::with_vars(
+            [("KF_JIRA_USER", Some("user@example.com")), ("KF_JIRA_TOKEN", None)],
+            || {
+                let err = JiraAuth::from_env().expect_err("should reject user without token");
+                assert!(err.to_string().contains("KF_JIRA_TOKEN"));
+            },
+        );
+    }
+
+    #[test]
+    fn jira_auth_rejects_user_that_is_not_an_email() {
+        temp_env::with_vars(
+            [("KF_JIRA_USER", Some("not-an-email")), ("KF_JIRA_TOKEN", Some("test-token"))],
+            || {
+                let err = JiraAuth::from_env().expect_err("should reject non-email user");
+                assert!(err.to_string().contains("email address"));
+            },
+        );
+    }
+
+    #[test]
+    fn jira_auth_is_anonymous_without_credentials() {
+        temp_env::with_vars([("KF_JIRA_USER", None::<&str>), ("KF_JIRA_TOKEN", None)], || {
+            assert_eq!(
+                JiraAuth::from_env().expect("should allow anonymous access"),
+                JiraAuth::Anonymous
+            );
+        });
     }
 
     #[test]
@@ -864,10 +898,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        let comments =
-            fetch_comments(&Url::parse(&server.uri()).expect("server URL"), "TEST-1", false)
-                .await
-                .expect("comments should be fetched");
+        let comments = without_jira_credentials(fetch_comments(
+            &Url::parse(&server.uri()).expect("server URL"),
+            "TEST-1",
+            false,
+        ))
+        .await
+        .expect("comments should be fetched");
 
         assert_eq!(comments.len(), 3);
         assert_eq!(comments[0].pointer("/body"), Some(&json!("first")));
@@ -897,8 +934,9 @@ mod tests {
             .await;
 
         let jira_url = Url::parse(&format!("{}/jira", server.uri())).expect("server URL");
-        let comments =
-            fetch_comments(&jira_url, "TEST-1", false).await.expect("comments should be fetched");
+        let comments = without_jira_credentials(fetch_comments(&jira_url, "TEST-1", false))
+            .await
+            .expect("comments should be fetched");
 
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0].pointer("/body"), Some(&json!("first")));

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -19,6 +19,12 @@ const JIRA_COMMENTS_PAGE_SIZE: u32 = 1000;
 /// scanning the same content.
 const JIRA_SEARCH_FIELDS: &str = "*all";
 
+/// Issues requested per JQL search request.
+///
+/// `--max-results` is a total, not a page size, so searches page until that
+/// many issues have been collected.
+const JIRA_ISSUES_PAGE_SIZE: usize = 100;
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DownloadIssueArtifactsOptions {
     pub include_comments: bool,
@@ -379,15 +385,45 @@ pub async fn fetch_issues(
 ) -> Result<Vec<JiraIssue>> {
     let jira = build_jira_client(jira_url, ignore_certs)?;
 
-    // `fields` must be set explicitly: leaving it unset makes the client
-    // substitute a minimal field set on Jira Cloud. See JIRA_SEARCH_FIELDS.
-    let search_options = SearchOptions::builder()
-        .max_results(max_results as u64)
-        .fields(vec![JIRA_SEARCH_FIELDS])
-        .build();
+    let mut issues: Vec<JiraIssue> = Vec::new();
+    // Jira Cloud paginates with an opaque cursor, Server/Data Center by
+    // offset. Both report `is_last_page`, so only the way forward differs.
+    let mut start_at: u64 = 0;
+    let mut next_page_token: Option<String> = None;
 
-    let results = jira.search().list(jql, &search_options).await?;
-    Ok(results.issues)
+    while issues.len() < max_results {
+        let page_size = std::cmp::min(JIRA_ISSUES_PAGE_SIZE, max_results - issues.len());
+
+        let mut options = SearchOptions::builder();
+        // `fields` must be set explicitly: leaving it unset makes the client
+        // substitute a minimal field set on Jira Cloud. See JIRA_SEARCH_FIELDS.
+        options.max_results(page_size as u64).fields(vec![JIRA_SEARCH_FIELDS]);
+        if let Some(token) = &next_page_token {
+            options.next_page_token(token);
+        } else if start_at > 0 {
+            options.start_at(start_at);
+        }
+
+        // Errors propagate rather than truncating the scan: a rate limit or
+        // expired token partway through must not look like "no more issues".
+        let results = jira.search().list(jql, &options.build()).await?;
+        let received = results.issues.len();
+        issues.extend(results.issues);
+
+        // An empty page means there is no progress left to make, which keeps
+        // the loop bounded even if the server keeps advertising more pages.
+        if received == 0 || results.is_last_page == Some(true) {
+            break;
+        }
+
+        match results.next_page_token {
+            Some(token) => next_page_token = Some(token),
+            None => start_at += received as u64,
+        }
+    }
+
+    issues.truncate(max_results);
+    Ok(issues)
 }
 
 pub async fn fetch_comments(
@@ -503,7 +539,7 @@ mod tests {
     use url::Url;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
-        matchers::{method, path, query_param},
+        matchers::{method, path, query_param, query_param_is_missing},
     };
 
     /// Runs `future` with Jira credentials cleared, so the test does not depend
@@ -955,6 +991,132 @@ mod tests {
 
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0].pointer("/body"), Some(&json!("first")));
+    }
+
+    /// Builds `count` minimally valid issues starting at `first_id`.
+    fn issue_page(first_id: usize, count: usize) -> Vec<serde_json::Value> {
+        (first_id..first_id + count)
+            .map(|n| {
+                json!({
+                    "self": format!("https://jira.example.com/rest/api/latest/issue/TEST-{n}"),
+                    "key": format!("TEST-{n}"),
+                    "id": n.to_string(),
+                    "fields": {"summary": format!("issue {n}")}
+                })
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn fetch_issues_pages_beyond_a_single_request() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let server = MockServer::start().await;
+
+        // `--max-results` is a total, not a page size, so more issues than one
+        // request returns must still come back.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param_is_missing("startAt"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 150,
+                "maxResults": 100,
+                "startAt": 0,
+                "issues": issue_page(1, 100)
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param("startAt", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 150,
+                "maxResults": 50,
+                "startAt": 100,
+                "issues": issue_page(101, 50)
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let jira_url = Url::parse(&server.uri()).expect("server URL");
+        let issues =
+            without_jira_credentials(fetch_issues(&jira_url, "project = TEST", 150, false))
+                .await
+                .expect("issues should be fetched");
+
+        assert_eq!(issues.len(), 150);
+        assert_eq!(issues[0].key, "TEST-1");
+        assert_eq!(issues[149].key, "TEST-150");
+    }
+
+    #[tokio::test]
+    async fn fetch_issues_stops_at_max_results() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let server = MockServer::start().await;
+
+        // Only one request is allowed: 40 issues are requested, so the second
+        // page must never be asked for.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param("maxResults", "40"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 500,
+                "maxResults": 40,
+                "startAt": 0,
+                "issues": issue_page(1, 40)
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let jira_url = Url::parse(&server.uri()).expect("server URL");
+        let issues = without_jira_credentials(fetch_issues(&jira_url, "project = TEST", 40, false))
+            .await
+            .expect("issues should be fetched");
+
+        assert_eq!(issues.len(), 40);
+    }
+
+    #[tokio::test]
+    async fn fetch_issues_propagates_errors_instead_of_truncating() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param_is_missing("startAt"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 150,
+                "maxResults": 100,
+                "startAt": 0,
+                "issues": issue_page(1, 100)
+            })))
+            .mount(&server)
+            .await;
+
+        // A failure partway through pagination must surface. Returning the
+        // first page as if it were the whole result set would under-report
+        // findings without any signal to the user.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param("startAt", "100"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+
+        let jira_url = Url::parse(&server.uri()).expect("server URL");
+        let result =
+            without_jira_credentials(fetch_issues(&jira_url, "project = TEST", 150, false)).await;
+
+        assert!(result.is_err(), "a mid-pagination failure must not be reported as success");
     }
 
     #[tokio::test]

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -9,6 +9,16 @@ pub use gouqi::Issue as JiraIssue;
 
 const JIRA_COMMENTS_PAGE_SIZE: u32 = 1000;
 
+/// Field selector sent with every JQL search.
+///
+/// Jira Cloud's `/rest/api/3/search/jql` returns only `id`, `key`, `summary`,
+/// and `status` unless `fields` is set explicitly, which would drop issue
+/// descriptions — the most likely place for a leaked secret — from every
+/// scanned issue. Requesting `*all` also picks up custom text fields, a common
+/// hiding place for credentials, and keeps Cloud and Server/Data Center
+/// scanning the same content.
+const JIRA_SEARCH_FIELDS: &str = "*all";
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DownloadIssueArtifactsOptions {
     pub include_comments: bool,
@@ -369,7 +379,12 @@ pub async fn fetch_issues(
 ) -> Result<Vec<JiraIssue>> {
     let jira = build_jira_client(jira_url, ignore_certs)?;
 
-    let search_options = SearchOptions::builder().max_results(max_results as u64).build();
+    // `fields` must be set explicitly: leaving it unset makes the client
+    // substitute a minimal field set on Jira Cloud. See JIRA_SEARCH_FIELDS.
+    let search_options = SearchOptions::builder()
+        .max_results(max_results as u64)
+        .fields(vec![JIRA_SEARCH_FIELDS])
+        .build();
 
     let results = jira.search().list(jql, &search_options).await?;
     Ok(results.issues)
@@ -482,7 +497,7 @@ pub async fn download_issues_to_dir(
 mod tests {
     use super::{
         JIRA_COMMENTS_PAGE_SIZE, JiraAuth, extract_adf_text, extract_embedded_comments,
-        fetch_comments, flatten_adf_fields, flatten_comment_bodies, is_adf,
+        fetch_comments, fetch_issues, flatten_adf_fields, flatten_comment_bodies, is_adf,
     };
     use serde_json::json;
     use url::Url;
@@ -940,5 +955,52 @@ mod tests {
 
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0].pointer("/body"), Some(&json!("first")));
+    }
+
+    #[tokio::test]
+    async fn fetch_issues_requests_all_fields() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let server = MockServer::start().await;
+
+        // Leaving `fields` unset makes the client substitute a minimal field
+        // set on Jira Cloud (`id`, `key`, `summary`, `status`), which drops
+        // issue descriptions from every result. Sending it explicitly is what
+        // keeps descriptions in the payload, so assert it is on the wire.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param("fields", "*all"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 1,
+                "maxResults": 50,
+                "startAt": 0,
+                "issues": [{
+                    "self": "https://jira.example.com/rest/api/latest/issue/TEST-1",
+                    "key": "TEST-1",
+                    "id": "10000",
+                    "fields": {
+                        "summary": "example",
+                        "description": "AKIAIOSFODNN7EXAMPLE"
+                    }
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let jira_url = Url::parse(&server.uri()).expect("server URL");
+        let issues = without_jira_credentials(fetch_issues(&jira_url, "project = TEST", 50, false))
+            .await
+            .expect("issues should be fetched");
+
+        assert_eq!(issues.len(), 1);
+        // The description must survive into the artifact that actually gets
+        // scanned, not just into the HTTP response.
+        let issue_value = super::normalize_issue(&issues[0]).expect("issue should normalize");
+        assert_eq!(
+            issue_value.pointer("/fields/description").and_then(|v| v.as_str()),
+            Some("AKIAIOSFODNN7EXAMPLE")
+        );
     }
 }

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -1054,6 +1054,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_issues_unbounded_stops_on_the_last_page() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let server = MockServer::start().await;
+
+        // `--all` passes usize::MAX, so the result limit can never stop the
+        // loop; only the server saying "last page" may.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param_is_missing("startAt"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 130,
+                "maxResults": 100,
+                "startAt": 0,
+                "issues": issue_page(1, 100)
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param("startAt", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 130,
+                "maxResults": 100,
+                "startAt": 100,
+                "issues": issue_page(101, 30)
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let jira_url = Url::parse(&server.uri()).expect("server URL");
+        let issues =
+            without_jira_credentials(fetch_issues(&jira_url, "project = TEST", usize::MAX, false))
+                .await
+                .expect("issues should be fetched");
+
+        assert_eq!(issues.len(), 130);
+        assert_eq!(issues[129].key, "TEST-130");
+    }
+
+    #[tokio::test]
     async fn fetch_issues_stops_at_max_results() {
         if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
             return;

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -276,7 +276,7 @@ fn build_http_client(ignore_certs: bool) -> Result<Client> {
 
 /// Jira authentication resolved from the environment.
 ///
-/// Jira Cloud (*.atlassian.net) API tokens must be sent as Basic auth with the
+/// Jira Cloud (`*.atlassian.net`) API tokens must be sent as Basic auth with the
 /// account email as the username; Bearer is reserved for OAuth 2.0 access
 /// tokens. Jira Server/Data Center Personal Access Tokens keep working as
 /// Bearer when `KF_JIRA_USER` is unset.

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -398,6 +398,7 @@ pub async fn fetch_issues(
 
         let mut options = SearchOptions::builder();
         options.max_results(page_size as u64).fields(vec![JIRA_SEARCH_FIELDS]);
+        let used_cursor = next_page_token.is_some();
         if let Some(token) = &next_page_token {
             options.next_page_token(token);
         } else if start_at > 0 {
@@ -419,6 +420,9 @@ pub async fn fetch_issues(
 
         match results.next_page_token {
             Some(token) => next_page_token = Some(token),
+            // Reusing a spent cursor re-requests the same page forever, and an
+            // offset means nothing to a cursor API.
+            None if used_cursor => break,
             None => start_at += received as u64,
         }
     }
@@ -1061,6 +1065,51 @@ mod tests {
         assert_eq!(issues.len(), 150);
         assert_eq!(issues[0].key, "TEST-1");
         assert_eq!(issues[149].key, "TEST-150");
+    }
+
+    #[tokio::test]
+    async fn fetch_issues_stops_when_the_cursor_dries_up() {
+        if std::net::TcpListener::bind(("127.0.0.1", 0)).is_err() {
+            return;
+        }
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param_is_missing("nextPageToken"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 10_000,
+                "maxResults": 100,
+                "startAt": 0,
+                "issues": issue_page(1, 100),
+                "next_page_token": "abc123"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // The cursor dries up without a "last page" flag, so the mock may only
+        // be hit once: reusing the spent token would loop here forever.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/latest/search"))
+            .and(query_param("nextPageToken", "abc123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 10_000,
+                "maxResults": 100,
+                "startAt": 0,
+                "issues": issue_page(101, 50)
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let jira_url = Url::parse(&server.uri()).expect("server URL");
+        let issues =
+            without_jira_credentials(fetch_issues(&jira_url, "project = TEST", usize::MAX, false))
+                .await
+                .expect("issues should be fetched");
+
+        assert_eq!(issues.len(), 150);
     }
 
     #[tokio::test]

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -270,11 +270,26 @@ fn build_http_client(ignore_certs: bool) -> Result<Client> {
 /// Basic auth with the account email; Bearer is for OAuth 2.0 tokens and
 /// Server/Data Center PATs. Search and comment fetching both resolve auth here
 /// so the two cannot drift apart.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 enum JiraAuth {
     Basic { user: String, token: String },
     Bearer(String),
     Anonymous,
+}
+
+// Hand-written so a token cannot reach logs or a failed assertion's output.
+// The account email is kept: it is not a credential and is the useful part
+// when diagnosing which identity was picked up.
+impl std::fmt::Debug for JiraAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Basic { user, .. } => {
+                f.debug_struct("Basic").field("user", user).field("token", &"<redacted>").finish()
+            }
+            Self::Bearer(_) => f.debug_tuple("Bearer").field(&"<redacted>").finish(),
+            Self::Anonymous => f.write_str("Anonymous"),
+        }
+    }
 }
 
 impl JiraAuth {
@@ -547,6 +562,21 @@ mod tests {
                 );
             },
         );
+    }
+
+    #[test]
+    fn jira_auth_debug_never_reveals_the_token() {
+        // `assert_eq!` prints the value on failure, so a derived Debug would
+        // put credentials in test output and in any log that formats them.
+        let basic = JiraAuth::Basic {
+            user: "user@example.com".to_string(),
+            token: "super-secret-token".to_string(),
+        };
+        let rendered = format!("{:?} {:?}", basic, JiraAuth::Bearer("super-secret-token".into()));
+
+        assert!(!rendered.contains("super-secret-token"), "token leaked into Debug: {rendered}");
+        assert!(rendered.contains("<redacted>"));
+        assert!(rendered.contains("user@example.com"));
     }
 
     #[test]

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -270,6 +270,9 @@ fn jira_credentials_env() -> Result<(Option<String>, Option<String>)> {
         bail!("KF_JIRA_USER must be an email address");
     }
     let token = std::env::var("KF_JIRA_TOKEN").ok();
+    if user.is_some() && token.is_none() {
+        bail!("KF_JIRA_USER is set but KF_JIRA_TOKEN is not; Jira Cloud Basic auth requires both");
+    }
     Ok((user, token))
 }
 
@@ -461,14 +464,67 @@ pub async fn download_issues_to_dir(
 mod tests {
     use super::{
         JIRA_COMMENTS_PAGE_SIZE, extract_adf_text, extract_embedded_comments, fetch_comments,
-        flatten_adf_fields, flatten_comment_bodies, is_adf,
+        flatten_adf_fields, flatten_comment_bodies, is_adf, jira_credentials_env,
     };
     use serde_json::json;
+    use std::ffi::OsString;
+    use std::sync::Mutex;
     use url::Url;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{method, path, query_param},
     };
+
+    static JIRA_ENV: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::remove_var(key) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn jira_credentials_env_rejects_user_without_token() {
+        let _lock = JIRA_ENV.lock().unwrap();
+        let _user = EnvVarGuard::set("KF_JIRA_USER", "user@example.com");
+        let _token = EnvVarGuard::unset("KF_JIRA_TOKEN");
+
+        let err = jira_credentials_env().expect_err("should reject user without token");
+        assert!(err.to_string().contains("KF_JIRA_TOKEN"));
+    }
+
+    #[test]
+    fn jira_credentials_env_accepts_user_and_token() {
+        let _lock = JIRA_ENV.lock().unwrap();
+        let _user = EnvVarGuard::set("KF_JIRA_USER", "user@example.com");
+        let _token = EnvVarGuard::set("KF_JIRA_TOKEN", "test-token");
+
+        let (user, token) = jira_credentials_env().expect("should accept user and token");
+        assert_eq!(user.as_deref(), Some("user@example.com"));
+        assert_eq!(token.as_deref(), Some("test-token"));
+    }
 
     #[test]
     fn is_adf_detects_doc_root() {

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -9,20 +9,12 @@ pub use gouqi::Issue as JiraIssue;
 
 const JIRA_COMMENTS_PAGE_SIZE: u32 = 1000;
 
-/// Field selector sent with every JQL search.
-///
-/// Jira Cloud's `/rest/api/3/search/jql` returns only `id`, `key`, `summary`,
-/// and `status` unless `fields` is set explicitly, which would drop issue
-/// descriptions — the most likely place for a leaked secret — from every
-/// scanned issue. Requesting `*all` also picks up custom text fields, a common
-/// hiding place for credentials, and keeps Cloud and Server/Data Center
-/// scanning the same content.
+/// Field selector sent with every JQL search. Left unset, Jira Cloud returns
+/// only `id`, `key`, `summary`, and `status`, silently dropping issue
+/// descriptions from the scan.
 const JIRA_SEARCH_FIELDS: &str = "*all";
 
-/// Issues requested per JQL search request.
-///
-/// `--max-results` is a total, not a page size, so searches page until that
-/// many issues have been collected.
+/// Issues per search request; `--max-results` is a total, not a page size.
 const JIRA_ISSUES_PAGE_SIZE: usize = 100;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -274,15 +266,10 @@ fn build_http_client(ignore_certs: bool) -> Result<Client> {
         .context("Failed to build HTTP client")
 }
 
-/// Jira authentication resolved from the environment.
-///
-/// Jira Cloud (`*.atlassian.net`) API tokens must be sent as Basic auth with the
-/// account email as the username; Bearer is reserved for OAuth 2.0 access
-/// tokens. Jira Server/Data Center Personal Access Tokens keep working as
-/// Bearer when `KF_JIRA_USER` is unset.
-///
-/// The JQL search goes through `gouqi` while comments are fetched directly, so
-/// both paths resolve auth here to keep them from drifting apart.
+/// Jira authentication resolved from the environment. Cloud API tokens need
+/// Basic auth with the account email; Bearer is for OAuth 2.0 tokens and
+/// Server/Data Center PATs. Search and comment fetching both resolve auth here
+/// so the two cannot drift apart.
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum JiraAuth {
     Basic { user: String, token: String },
@@ -386,8 +373,8 @@ pub async fn fetch_issues(
     let jira = build_jira_client(jira_url, ignore_certs)?;
 
     let mut issues: Vec<JiraIssue> = Vec::new();
-    // Jira Cloud paginates with an opaque cursor, Server/Data Center by
-    // offset. Both report `is_last_page`, so only the way forward differs.
+    // Cloud paginates by cursor, Server/Data Center by offset; both report
+    // `is_last_page`.
     let mut start_at: u64 = 0;
     let mut next_page_token: Option<String> = None;
 
@@ -395,8 +382,6 @@ pub async fn fetch_issues(
         let page_size = std::cmp::min(JIRA_ISSUES_PAGE_SIZE, max_results - issues.len());
 
         let mut options = SearchOptions::builder();
-        // `fields` must be set explicitly: leaving it unset makes the client
-        // substitute a minimal field set on Jira Cloud. See JIRA_SEARCH_FIELDS.
         options.max_results(page_size as u64).fields(vec![JIRA_SEARCH_FIELDS]);
         if let Some(token) = &next_page_token {
             options.next_page_token(token);
@@ -404,14 +389,15 @@ pub async fn fetch_issues(
             options.start_at(start_at);
         }
 
-        // Errors propagate rather than truncating the scan: a rate limit or
-        // expired token partway through must not look like "no more issues".
+        // Errors propagate: a rate limit partway through must not look like
+        // "no more issues". This is why `stream()` is unused — it maps a failed
+        // page to end-of-stream.
         let results = jira.search().list(jql, &options.build()).await?;
         let received = results.issues.len();
         issues.extend(results.issues);
 
-        // An empty page means there is no progress left to make, which keeps
-        // the loop bounded even if the server keeps advertising more pages.
+        // An empty page keeps the loop bounded if the server keeps advertising
+        // more.
         if received == 0 || results.is_last_page == Some(true) {
             break;
         }
@@ -542,9 +528,6 @@ mod tests {
         matchers::{method, path, query_param, query_param_is_missing},
     };
 
-    /// Runs `future` with Jira credentials cleared, so the test does not depend
-    /// on the developer's own shell (a stray `KF_JIRA_USER` would now be a
-    /// hard error rather than a silent fallback to anonymous).
     async fn without_jira_credentials<T>(future: impl std::future::Future<Output = T>) -> T {
         temp_env::async_with_vars([("KF_JIRA_USER", None::<&str>), ("KF_JIRA_TOKEN", None)], future)
             .await
@@ -993,7 +976,6 @@ mod tests {
         assert_eq!(comments[0].pointer("/body"), Some(&json!("first")));
     }
 
-    /// Builds `count` minimally valid issues starting at `first_id`.
     fn issue_page(first_id: usize, count: usize) -> Vec<serde_json::Value> {
         (first_id..first_id + count)
             .map(|n| {
@@ -1014,8 +996,6 @@ mod tests {
         }
         let server = MockServer::start().await;
 
-        // `--max-results` is a total, not a page size, so more issues than one
-        // request returns must still come back.
         Mock::given(method("GET"))
             .and(path("/rest/api/latest/search"))
             .and(query_param_is_missing("startAt"))
@@ -1060,8 +1040,7 @@ mod tests {
         }
         let server = MockServer::start().await;
 
-        // `--all` passes usize::MAX, so the result limit can never stop the
-        // loop; only the server saying "last page" may.
+        // `--all` passes usize::MAX: only "last page" may stop the loop.
         Mock::given(method("GET"))
             .and(path("/rest/api/latest/search"))
             .and(query_param_is_missing("startAt"))
@@ -1105,8 +1084,6 @@ mod tests {
         }
         let server = MockServer::start().await;
 
-        // Only one request is allowed: 40 issues are requested, so the second
-        // page must never be asked for.
         Mock::given(method("GET"))
             .and(path("/rest/api/latest/search"))
             .and(query_param("maxResults", "40"))
@@ -1147,9 +1124,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        // A failure partway through pagination must surface. Returning the
-        // first page as if it were the whole result set would under-report
-        // findings without any signal to the user.
+        // Returning the first page as the whole result set would under-report
+        // findings with no signal to the user.
         Mock::given(method("GET"))
             .and(path("/rest/api/latest/search"))
             .and(query_param("startAt", "100"))
@@ -1171,10 +1147,7 @@ mod tests {
         }
         let server = MockServer::start().await;
 
-        // Leaving `fields` unset makes the client substitute a minimal field
-        // set on Jira Cloud (`id`, `key`, `summary`, `status`), which drops
-        // issue descriptions from every result. Sending it explicitly is what
-        // keeps descriptions in the payload, so assert it is on the wire.
+        // Unset, Cloud substitutes a minimal field set and drops descriptions.
         Mock::given(method("GET"))
             .and(path("/rest/api/latest/search"))
             .and(query_param("fields", "*all"))
@@ -1202,8 +1175,7 @@ mod tests {
             .expect("issues should be fetched");
 
         assert_eq!(issues.len(), 1);
-        // The description must survive into the artifact that actually gets
-        // scanned, not just into the HTTP response.
+        // Must survive into the scanned artifact, not just the HTTP response.
         let issue_value = super::normalize_issue(&issues[0]).expect("issue should normalize");
         assert_eq!(
             issue_value.pointer("/fields/description").and_then(|v| v.as_str()),

--- a/tests/cli_jira_confluence_all.rs
+++ b/tests/cli_jira_confluence_all.rs
@@ -1,0 +1,118 @@
+use clap::Parser;
+
+use kingfisher::cli::{
+    commands::scan::{ScanOperation, UNLIMITED_RESULTS},
+    global::{Command, CommandLineArgs},
+};
+
+fn scan_args_from(argv: &[&str]) -> anyhow::Result<kingfisher::cli::commands::scan::ScanArgs> {
+    let args = CommandLineArgs::try_parse_from(argv)?;
+
+    let command = match args.command {
+        Command::Scan(scan_args) => scan_args,
+        other => panic!("unexpected command parsed: {:?}", other),
+    };
+
+    match command.into_operation()? {
+        ScanOperation::Scan(scan_args) => Ok(scan_args),
+        op => panic!("expected scan operation, got {:?}", op),
+    }
+}
+
+#[test]
+fn jira_all_lifts_the_result_limit() -> anyhow::Result<()> {
+    let scan_args = scan_args_from(&[
+        "kingfisher",
+        "scan",
+        "jira",
+        "--url",
+        "https://example.atlassian.net",
+        "--jql",
+        "project = TEST",
+        "--all",
+        "--no-update-check",
+    ])?;
+
+    assert_eq!(scan_args.input_specifier_args.max_results, UNLIMITED_RESULTS);
+
+    Ok(())
+}
+
+#[test]
+fn confluence_all_lifts_the_result_limit() -> anyhow::Result<()> {
+    let scan_args = scan_args_from(&[
+        "kingfisher",
+        "scan",
+        "confluence",
+        "--url",
+        "https://example.atlassian.net/wiki",
+        "--cql",
+        "label = secret",
+        "--all",
+        "--no-update-check",
+    ])?;
+
+    assert_eq!(scan_args.input_specifier_args.max_results, UNLIMITED_RESULTS);
+
+    Ok(())
+}
+
+#[test]
+fn jira_defaults_to_a_bounded_result_limit() -> anyhow::Result<()> {
+    let scan_args = scan_args_from(&[
+        "kingfisher",
+        "scan",
+        "jira",
+        "--url",
+        "https://example.atlassian.net",
+        "--jql",
+        "project = TEST",
+        "--no-update-check",
+    ])?;
+
+    assert_eq!(scan_args.input_specifier_args.max_results, 100);
+
+    Ok(())
+}
+
+#[test]
+fn jira_all_conflicts_with_an_explicit_max_results() {
+    // The default value of `--max-results` must not trigger the conflict, but
+    // passing both explicitly is contradictory and should be rejected.
+    let err = CommandLineArgs::try_parse_from([
+        "kingfisher",
+        "scan",
+        "jira",
+        "--url",
+        "https://example.atlassian.net",
+        "--jql",
+        "project = TEST",
+        "--all",
+        "--max-results",
+        "5",
+        "--no-update-check",
+    ])
+    .expect_err("--all and --max-results must conflict");
+
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn confluence_all_conflicts_with_an_explicit_max_results() {
+    let err = CommandLineArgs::try_parse_from([
+        "kingfisher",
+        "scan",
+        "confluence",
+        "--url",
+        "https://example.atlassian.net/wiki",
+        "--cql",
+        "label = secret",
+        "--all",
+        "--max-results",
+        "5",
+        "--no-update-check",
+    ])
+    .expect_err("--all and --max-results must conflict");
+
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}


### PR DESCRIPTION
## ⚠️ Reviewer note first

Two things in here deserve explicit attention before the rest:

1. **This PR changes a shipped detection rule.** `kingfisher.atlassian.1`'s pattern is tightened to stop matching Jira/Confluence `accountId` values. That is a detection-semantics change with a false-negative trade-off — details in the section below. It is bundled here because the false positive fires precisely on the artifacts this PR makes scannable at scale (issue comments), but it is happy to be split out if you would rather review it separately.
2. **A validation bug is reported but deliberately left unfixed:** live Atlassian API tokens are labelled `"Inactive Credential"`, because `kingfisher.atlassian.1` validates with `Bearer` against an endpoint that only accepts OAuth 2.0 access tokens. There is no drop-in fix (Basic auth needs the paired email), so the remedy is a maintainer call. Filed as **#461** — nothing in this PR touches the `validation:` block.

---

## Summary

Adds Jira Cloud / Confluence Cloud support to the `jira` and `confluence` scanners. Most of the fixes below are silent failures — the scan completes and reports success while content goes unscanned.

- **Auth**: add `KF_JIRA_USER` (mirroring the existing `KF_CONFLUENCE_USER`) so Jira Cloud API tokens authenticate with HTTP Basic auth (account email + token). Bearer only works for Server/Data Center PATs or OAuth 2.0 access tokens. Setting `KF_JIRA_USER` without `KF_JIRA_TOKEN` is now a hard error instead of a silent fallback to anonymous.
- **Jira issue descriptions were never scanned on Cloud.** `fetch_issues` left `fields` unset, so the client substituted a minimal set (`id`, `key`, `summary`, `status`) on the Cloud search path. Descriptions — the most likely place for a leaked secret — were absent from every issue artifact, and the ADF flattening had nothing to flatten. Easy to miss because `--include-comments` / `--include-changelog` use their own endpoints and keep working. Now sends `fields=*all`.
- **`--max-results` was capped at one page.** `fetch_issues` made a single request and ignored the continuation token, so asking for 1000 issues returned ~100 and reported success. It is now treated as a total: search pages 100 at a time, following Cloud's cursor or Server/Data Center's offset.
- **New `--all` flag** for `scan jira` and `scan confluence`, lifting the result bound entirely so a whole project or space can be scanned without guessing a number. Follows the existing `scan postman --all` idiom rather than overloading `--max-results 0`, which already means "fetch nothing". It conflicts with an explicit `--max-results` but not with its default.
- **Confluence pagination on Cloud.** Cloud removed offset-based `start` pagination for `/rest/api/content/search` in 2020 in favour of a server-issued cursor, so scans past page one returned wrong or incomplete results. Kingfisher now follows `_links.next`, re-anchored onto the configured base URL so the `/wiki` context path is not lost (Cloud returns `next` root-relative, without `/wiki`).
- **Two hardening fixes in that pagination**: an empty result page returned alongside a `next` link could loop forever (CONFCLOUD-84279); and adopting the server's query string wholesale could drop `expand=body.storage`, blanking page bodies after page one. Missing `cql` / `limit` / `expand` are now restored, and links without pagination state are not followed.

Jira's JQL search needed no routing change: `gouqi` (already vendored at 0.20.0) detects `*.atlassian.net` hosts and routes through `/rest/api/3/search/jql`, since Atlassian removed the legacy `/rest/api/2/search` for Cloud.

Docs (`docs/INTEGRATIONS.md`, `docs/USAGE.md`, `README.md` and the `docs-site/` mirrors) updated with Cloud usage, the new env var, and the `--max-results` semantics.

Fixes #459

## The detection-rule change (please review on its own merits)

`kingfisher.atlassian.1` anchored on the bare vendor name, which appears in every `*.atlassian.net` URL, then captured any 24-character alphanumeric run within the next 32 characters. Jira and Confluence author blocks put an `accountId` exactly that far behind the hostname:

```
https://example.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g
                └anchor─┘└──────────31 chars───────────┘└───────24 alnum───────┘
```

Every comment author was therefore reported as an Atlassian API token (entropy 3.61, above the 3.5 floor), once per author.

`ignore_if_contains` cannot express this — the substring check runs against the capture, not the surrounding match (verified experimentally), and Vectorscan supports no lookaround. The available lever is requiring a credential keyword after the vendor name. Both existing `examples` already carry one (`Atlassian_key`, `ATLASSIAN_API_TOKEN`) and still match.

**Trade-off to weigh:** a real token whose only nearby context is the word "atlassian", with no `token`/`key`/`secret`/`password` within 20 characters, will no longer match. `testdata` contains no Atlassian fixtures, so the corpus gives no signal either way.

`kingfisher.atlassian.3` is untouched and unaffected — its `AT` + 60-260 character shape cannot match a 24-character accountId.

## Notes for reviewers

- `fields=*all` widens Server/Data Center from its implicit `*navigable` default. Intentional for a scanner, at the cost of larger responses.
- Pagination deliberately does not use the client's `stream()` helper, which maps a failed page to end-of-stream (`Poll::Ready(Err(_)) => Poll::Ready(None)`). A rate limit partway through would look like "no more issues" and under-report findings. The explicit loop propagates errors; a test covers it.
- Deployment detection keys off an `.atlassian.net` hostname, so a mock server always takes the V2 path and Cloud-specific behaviour cannot be reproduced locally. Tests assert what is observable: that `fields=*all` reaches the wire, that a description survives into the normalized artifact, and that offset pagination advances.

## Test plan
- [x] `cargo test --lib` — 549 passed
- [x] `cargo test --test cli_jira_confluence_all` — 5 passed (`--all` wiring and conflict rules)
- [x] `cargo test --lib -- jira:: confluence::` — 35 passed (20 before this branch)
- [x] `cargo test -p kingfisher-rules --lib` — 55 passed (the crate's one failing doctest is pre-existing on `main`)
- [x] `kingfisher rules check --rules-path crates/kingfisher-rules/data/rules/atlassian.yml --load-builtins=false`
- [x] `cargo fmt --check`; `cargo clippy --lib -p kingfisher --all-targets` (clean on touched files; one pre-existing unrelated warning in `kingfisher-core`)
- [x] Each scanner fix verified by reverting it: the empty-page guard hangs the suite, the field selector fails with `NotFound`, the single-request form fails pagination with `left: 100, right: 150`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

