### PR TITLE
Fix hang with jobs=1 and add offline Ethereum key detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.112.0]
+- Added offline Ethereum key/BIP-39 detection with explicit local-validation outcomes, inspired by [#468](https://github.com/mongodb/kingfisher/pull/468) from @audityourcontracts.
+- Hardened validation caching and panic handling to avoid secret exposure.
+- Fixed remote Git URL scans hanging with `--jobs 1`. [#469](https://github.com/mongodb/kingfisher/issues/469)
+
 ## [v1.111.0]
 - Reduced Git scan metadata memory usage by interning repeated committer names and email addresses.
 - Reduced peak memory during large scans by bounding Git delta caches per worker and streaming matcher chunks; `--jobs` now controls the scanner worker pool.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bip32"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db40d3dfbeab4e031d78c844642fa0caa0b0db11ce1607ac9d2986dff1405c69"
+dependencies = [
+ "bs58",
+ "hmac 0.12.1",
+ "k256",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "serde",
+ "unicode-normalization",
+ "zeroize",
+]
+
+[[package]]
 name = "bisync"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1262,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
+dependencies = [
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -1404,6 +1442,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -1733,7 +1772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3629,7 +3668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
 dependencies = [
  "bstr",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4356,6 +4395,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hickory-net"
@@ -5125,6 +5173,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "keyed_priority_queue"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5135,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "kingfisher"
-version = "1.111.0"
+version = "1.112.0"
 dependencies = [
  "anyhow",
  "asar",
@@ -5300,6 +5370,7 @@ dependencies = [
  "anyhow",
  "base32",
  "base64 0.23.1",
+ "bip39",
  "crc32fast",
  "flate2",
  "hex",
@@ -5326,6 +5397,7 @@ dependencies = [
  "vectorscan-rs",
  "walkdir",
  "xxhash-rust",
+ "zeroize",
 ]
 
 [[package]]
@@ -5344,6 +5416,8 @@ dependencies = [
  "aws-types",
  "base32",
  "base64 0.23.1",
+ "bip32",
+ "bip39",
  "bstr",
  "byteorder",
  "chrono",
@@ -5377,6 +5451,7 @@ dependencies = [
  "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",
+ "sha3",
  "smallvec",
  "tempfile",
  "thiserror 2.0.19",
@@ -5390,6 +5465,7 @@ dependencies = [
  "url",
  "vectorscan-rs",
  "xxhash-rust",
+ "zeroize",
 ]
 
 [[package]]
@@ -7432,6 +7508,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7763,6 +7848,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8059,6 +8162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8251,6 +8365,12 @@ dependencies = [
  "base64ct",
  "der 0.8.1",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sqlite-wasm-rs"
@@ -8507,7 +8627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -9725,7 +9845,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ publish = false
 
 [workspace.dependencies]
 anyhow = "1.0"
+bip32 = { version = "0.5.3", default-features = false, features = ["secp256k1", "std"] }
+bip39 = { version = "2.2.2", default-features = false, features = ["std", "zeroize"] }
 thiserror = "2.0.18"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -33,6 +35,7 @@ ignore = "0.4"
 walkdir = "2.5"
 sha1 = "0.11"
 sha2 = "0.11"
+sha3 = { version = "0.12", default-features = false }
 hmac = "0.13"
 base32 = "0.5.1"
 base64 = "0.23"
@@ -43,11 +46,12 @@ rand = "0.10"
 hex = "0.4"
 rustc-hash = "2.1"
 http = "1.4"
+zeroize = "1.8"
 
 
 [package]
 name = "kingfisher"
-version = "1.111.0"
+version = "1.112.0"
 description = "MongoDB's blazingly fast and accurate secret scanning and validation tool"
 edition.workspace = true
 rust-version.workspace = true

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License" style="height: 24px;" />
   </a>
   <a href="https://github.com/mongodb/kingfisher">
-    <img src="https://img.shields.io/badge/Detection%20Rules-1051-2ea043.svg" alt="Detection Rules" style="height: 24px;" />
+    <img src="https://img.shields.io/badge/Detection%20Rules-1089-2ea043.svg" alt="Detection Rules" style="height: 24px;" />
   </a>
   <br>
   <a href="https://github.com/mongodb/kingfisher/pkgs/container/kingfisher">
@@ -20,7 +20,7 @@
 
 Kingfisher is an open source secret scanner and **live secret validation** tool built in Rust.
 
-It combines Intel's SIMD-accelerated regex engine (Hyperscan) with language-aware parsing to achieve high accuracy at massive scale, and ships with [1,051 built-in rules](https://mongodb.github.io/kingfisher/rules/builtin-rules/) to detect, **validate**, and triage leaked API keys, tokens, and credentials before they ever reach production.
+It combines Intel's SIMD-accelerated regex engine (Hyperscan) with language-aware parsing to achieve high accuracy at massive scale, and ships with [1,089 built-in rules](https://mongodb.github.io/kingfisher/rules/builtin-rules/) to detect, **validate**, and triage leaked API keys, tokens, and credentials before they ever reach production.
 
 Kingfisher also ships a **browser-based report viewer** that visualizes and triages findings from Kingfisher, SARIF, Gitleaks, and TruffleHog reports — so you can import scans from other tools and triage them in the same UI. A [hosted copy of the viewer](https://mongodb.github.io/kingfisher/viewer/) is published on the Kingfisher docs site [or run locally](#3-scan-and-view-results-in-browser)
 
@@ -55,9 +55,9 @@ Kingfisher is a high-performance, open source secret detection tool for source c
 
 </div>
 
-### Performance, Accuracy, and 1,051 Rules
+### Performance, Accuracy, and 1,089 Rules
 - **Performance**: multithreaded, Hyperscan‑powered scanning built for huge codebases  
-- **Extensible rules**: 1,051 built-in rules plus YAML-defined custom rules ([docs/RULES.md](/docs/RULES.md))
+- **Extensible rules**: 1,089 built-in rules plus YAML-defined custom rules ([docs/RULES.md](/docs/RULES.md))
 - **Validate & Revoke**: live validation of discovered secrets, plus direct revocation for supported platforms (GitHub, GitLab, Slack, AWS, GCP, and more) ([docs/USAGE.md](/docs/USAGE.md))
 - **Revocation support matrix**: current built-in revocation coverage across providers and rule IDs ([docs/REVOCATION_PROVIDERS.md](/docs/REVOCATION_PROVIDERS.md))
 - **Blast Radius Mapping**: instantly map leaked keys to their effective cloud identities and exposed resources with `--access-map` (alias `--blast-radius`). Supports 43 providers (see table below).
@@ -458,7 +458,7 @@ For payload shapes, per-webhook overrides, and config-file examples, see [docs/A
 
 # Detection Rules
 
-Kingfisher ships with [1,051 built-in rules](crates/kingfisher-rules/data/rules/) covering cloud keys, AI tokens, CI/CD secrets, database credentials, and SaaS API keys. Below is an overview — see the full list in [crates/kingfisher-rules/data/rules/](crates/kingfisher-rules/data/rules/):
+Kingfisher ships with [1,089 built-in rules](crates/kingfisher-rules/data/rules/) covering cloud keys, AI tokens, CI/CD secrets, database credentials, and SaaS API keys. Below is an overview — see the full list in [crates/kingfisher-rules/data/rules/](crates/kingfisher-rules/data/rules/):
 
 | Category | What we catch |
 |----------|---------------|
@@ -475,7 +475,7 @@ Kingfisher ships with [1,051 built-in rules](crates/kingfisher-rules/data/rules/
 
 ## Write Custom Rules
 
-Kingfisher ships with 1,051 built-in rules.
+Kingfisher ships with 1,089 built-in rules.
 
 However, you may want to add your own custom rules, or modify a detection to better suit your needs / environment.
 

--- a/crates/kingfisher-core/src/validation.rs
+++ b/crates/kingfisher-core/src/validation.rs
@@ -29,7 +29,11 @@ pub enum ValidationOutcome {
     VerifiedActive,
     /// The rule author marked the credential as valid without live validation.
     Assumed,
-    /// A live or cryptographic validator authoritatively rejected the credential.
+    /// Network-free cryptographic validation parsed the material and derived public evidence.
+    LocallyDerived,
+    /// Network-free cryptographic validation rejected malformed key material.
+    InvalidMaterial,
+    /// A live validator authoritatively rejected the credential.
     VerifiedInactive,
     /// Validation was attempted but infrastructure or the remote service was unavailable.
     Unavailable,
@@ -49,7 +53,7 @@ impl ValidationOutcome {
 
     /// Whether this outcome should pass the actionable validation filter.
     pub const fn is_actionable(self) -> bool {
-        matches!(self, Self::VerifiedActive | Self::Assumed)
+        matches!(self, Self::VerifiedActive | Self::Assumed | Self::LocallyDerived)
     }
 
     /// Stable human-readable label used by reports.
@@ -57,6 +61,8 @@ impl ValidationOutcome {
         match self {
             Self::VerifiedActive => "Active Credential",
             Self::Assumed => "Assumed Valid (Not Live-Validated)",
+            Self::LocallyDerived => "Locally Derived",
+            Self::InvalidMaterial => "Invalid Cryptographic Material",
             Self::VerifiedInactive => "Inactive Credential",
             Self::Unavailable => "Inconclusive Validation",
             Self::Skipped => "Validation Skipped",
@@ -94,6 +100,8 @@ mod tests {
     fn actionable_outcomes_are_explicit() {
         assert!(ValidationOutcome::VerifiedActive.is_actionable());
         assert!(ValidationOutcome::Assumed.is_actionable());
+        assert!(ValidationOutcome::LocallyDerived.is_actionable());
+        assert!(!ValidationOutcome::InvalidMaterial.is_actionable());
         assert!(!ValidationOutcome::VerifiedInactive.is_actionable());
         assert!(!ValidationOutcome::Unavailable.is_actionable());
         assert!(!ValidationOutcome::Skipped.is_actionable());
@@ -123,6 +131,14 @@ mod tests {
 
     #[test]
     fn outcome_serialization_is_stable_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ValidationOutcome::LocallyDerived).unwrap(),
+            "\"locally_derived\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ValidationOutcome::InvalidMaterial).unwrap(),
+            "\"invalid_material\""
+        );
         assert_eq!(
             serde_json::to_string(&ValidationOutcome::NotAttempted).unwrap(),
             "\"not_attempted\""

--- a/crates/kingfisher-rules/Cargo.toml
+++ b/crates/kingfisher-rules/Cargo.toml
@@ -37,6 +37,7 @@ liquid-core = "0.26"
 # Crypto for liquid filters
 base32.workspace = true
 base64.workspace = true
+bip39.workspace = true
 crc32fast = "1.5"
 hmac.workspace = true
 sha1.workspace = true
@@ -46,6 +47,7 @@ percent-encoding.workspace = true
 time.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 rand.workspace = true
+zeroize.workspace = true
 
 # Vectorscan for pattern matching
 vectorscan-rs.workspace = true

--- a/crates/kingfisher-rules/data/rules/bip39.yml
+++ b/crates/kingfisher-rules/data/rules/bip39.yml
@@ -1,0 +1,53 @@
+rules:
+  # A generic BIP-39 label proves key material, but not which chain uses it.
+  - name: BIP-39 Seed Phrase
+    id: kingfisher.bip39.1
+    pattern: |
+      (?xi)
+      ["']?
+      \b(?:mnemonic|seed[_-]?phrase|recovery[_-]?phrase)\b
+      ["']?
+      [[:blank:]]*
+      (?:[:=][[:blank:]]*|\([[:blank:]]*)
+      ["']?
+      (
+        (?P<mnemonic>
+          (?:
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){23}[[:alpha:]]{3,8}
+            |
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){20}[[:alpha:]]{3,8}
+            |
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){17}[[:alpha:]]{3,8}
+            |
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){14}[[:alpha:]]{3,8}
+            |
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){11}[[:alpha:]]{3,8}
+          )
+        )
+      )
+      (?:["'][[:blank:]]*|[[:blank:]]*)
+      (?:
+        [,;)\]}]
+        |
+        [\r\n]
+        |
+        (?:\#|//)[^\r\n]*(?:[\r\n]|$)
+        |
+        $
+      )
+    pattern_requirements:
+      checksum:
+        actual:
+          template: "{{ MNEMONIC | bip39_valid }}"
+          requires_capture: mnemonic
+        expected: "true"
+        skip_if_missing: false
+    min_entropy: 0.0
+    confidence: medium
+    validation:
+      type: Assumed
+    examples:
+      - '"mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"'
+      - "seed_phrase = abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+    references:
+      - https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki

--- a/crates/kingfisher-rules/data/rules/ethereum.yml
+++ b/crates/kingfisher-rules/data/rules/ethereum.yml
@@ -1,0 +1,155 @@
+rules:
+  - name: Ethereum Private Key
+    id: kingfisher.ethereum.1
+    pattern: |
+      (?xi)
+      (?:
+        ["']?
+        \b
+        (?:
+          (?:[[:alnum:]]{1,24}[_-]){0,4}
+          (?:ethereum|eth|evm)
+          (?:[_-][[:alnum:]]{1,24}){0,4}
+          [_-]private[_-]?key
+          |
+          (?:ethereum|eth|evm)privatekey
+          |
+          privatekeytoaccount
+        )
+        \b
+        ["']?
+      )
+      [[:blank:]]*
+      (?:
+        (?::[[:blank:]]*(?:hex|string|bytes32)[[:blank:]]*)?=[[:blank:]]*
+        |
+        :[[:blank:]]*
+        |
+        \([[:blank:]]*
+      )
+      ["']?
+      (
+        (?:0x)?[[:xdigit:]]{64}
+      )
+      \b
+    min_entropy: 0.0
+    confidence: medium
+    examples:
+      - "ETHEREUM_APP_PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000001"
+      - "EVM_PRIVATE_KEY: 0000000000000000000000000000000000000000000000000000000000000002"
+      - "ETH_WALLET_PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000003"
+      - 'privateKeyToAccount("0x0000000000000000000000000000000000000000000000000000000000000004")'
+    references:
+      - https://ethereum.org/en/developers/docs/accounts/
+      - https://www.secg.org/sec2-v2.pdf
+    validation:
+      type: Ethereum
+      content: private_key
+
+  - name: Ethereum BIP-39 Seed Phrase
+    id: kingfisher.ethereum.2
+    pattern: |
+      (?xi)
+      ["']?
+      \b
+      (?:
+        (?:[[:alnum:]]{1,24}[_-]){0,4}
+        (?:ethereum|eth|evm)
+        (?:[_-][[:alnum:]]{1,24}){0,4}
+        [_-](?:mnemonic|seed[_-]?phrase|recovery[_-]?phrase)
+        |
+        (?:ethereum|eth|evm)(?:mnemonic|seedphrase|recoveryphrase)
+      )
+      \b
+      ["']?
+      [[:blank:]]*
+      (?:[:=][[:blank:]]*|\([[:blank:]]*)
+      ["']?
+      (
+        (?P<mnemonic>
+          (?:
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){23}[[:alpha:]]{3,8}
+            |
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){20}[[:alpha:]]{3,8}
+            |
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){17}[[:alpha:]]{3,8}
+            |
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){14}[[:alpha:]]{3,8}
+            |
+            (?:[[:alpha:]]{3,8}[[:space:]]{1,16}){11}[[:alpha:]]{3,8}
+          )
+        )
+      )
+      (?:["'][[:blank:]]*|[[:blank:]]*)
+      (?:
+        [,;)\]}]
+        |
+        [\r\n]
+        |
+        (?:\#|//)[^\r\n]*(?:[\r\n]|$)
+        |
+        $
+      )
+    pattern_requirements:
+      checksum:
+        actual:
+          template: "{{ MNEMONIC | bip39_valid }}"
+          requires_capture: mnemonic
+        expected: "true"
+        skip_if_missing: false
+    min_entropy: 0.0
+    confidence: medium
+    examples:
+      - "ETHEREUM_MNEMONIC: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+      - "ethSeedPhrase = abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+    references:
+      - https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+      - https://ethereum.org/en/wallets/
+    validation:
+      type: Ethereum
+      content: mnemonic
+
+  # Public keys are identifiers, not credentials. This hidden helper is retained
+  # for deterministic address derivation and requires explicit chain context.
+  - name: Ethereum Public Key (Public Identifier)
+    id: kingfisher.ethereum.3
+    pattern: |
+      (?xi)
+      ["']?
+      \b
+      (?:
+        (?:[[:alnum:]]{1,24}[_-]){0,4}
+        (?:ethereum|eth|evm)
+        (?:[_-][[:alnum:]]{1,24}){0,4}
+        [_-](?:public[_-]?key|pubkey)
+        |
+        (?:ethereum|eth|evm)(?:publickey|pubkey)
+      )
+      \b
+      ["']?
+      [[:blank:]]*
+      (?:
+        (?::[[:blank:]]*(?:hex|string|bytes33|bytes65)[[:blank:]]*)?=[[:blank:]]*
+        |
+        :[[:blank:]]*
+        |
+        \([[:blank:]]*
+      )
+      ["']?
+      (
+        (?:0x)?(?:(?:02|03)[[:xdigit:]]{64}|04[[:xdigit:]]{128}|[[:xdigit:]]{128})
+      )
+      \b
+    min_entropy: 0.0
+    confidence: medium
+    visible: false
+    examples:
+      - "ETHEREUM_PUBLIC_KEY: 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+      - "ethereum_public_key = 0x0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      - "EVM_PUBLIC_KEY: 79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+    references:
+      - https://www.secg.org/sec1-v2.pdf
+      - https://ethereum.org/en/developers/docs/accounts/
+    validation:
+      type: Ethereum
+      content: public_key

--- a/crates/kingfisher-rules/src/lib.rs
+++ b/crates/kingfisher-rules/src/lib.rs
@@ -16,11 +16,11 @@ pub mod rules_database;
 
 // Re-export rule types
 pub use rule::{
-    ChecksumActual, ChecksumRequirement, Confidence, DependsOnRule, GrpcRequest, GrpcValidation,
-    HttpMultiStepRevocation, HttpRequest, HttpValidation, MultipartConfig, MultipartPart,
-    PatternRequirementContext, PatternRequirements, PatternValidationResult, RULE_COMMENTS_PATTERN,
-    ReportResponseData, ResponseExtractor, ResponseMatcher, Revocation, RevocationStep, Rule,
-    RuleSyntax, TlsMode, Validation,
+    ChecksumActual, ChecksumRequirement, Confidence, DependsOnRule, EthereumValidation,
+    GrpcRequest, GrpcValidation, HttpMultiStepRevocation, HttpRequest, HttpValidation,
+    MultipartConfig, MultipartPart, PatternRequirementContext, PatternRequirements,
+    PatternValidationResult, RULE_COMMENTS_PATTERN, ReportResponseData, ResponseExtractor,
+    ResponseMatcher, Revocation, RevocationStep, Rule, RuleSyntax, TlsMode, Validation,
 };
 
 // Re-export Rules collection

--- a/crates/kingfisher-rules/src/liquid_filters.rs
+++ b/crates/kingfisher-rules/src/liquid_filters.rs
@@ -529,19 +529,17 @@ static_filter!(
 static_filter!(
     /// Return whether the input is a checksum-valid English BIP-39 mnemonic.
     Bip39ValidFilter, "bip39_valid",
-    |input: &dyn ValueView| -> String {
+    |input: &dyn ValueView| -> bool {
         const MAX_MNEMONIC_BYTES: usize = 640;
         let input = input.to_kstr();
         if input.len() > MAX_MNEMONIC_BYTES {
-            return "false".to_string();
+            return false;
         }
 
         // This contains the full mnemonic. Keep `Zeroizing`: the crypto-inventory Semgrep rule
         // flags the crate generically, but wiping this temporary is intentional memory hygiene.
         let normalized = Zeroizing::new(input.split_whitespace().collect::<Vec<_>>().join(" "));
-        Mnemonic::parse_in_normalized(Language::English, &normalized)
-            .is_ok()
-            .to_string()
+        Mnemonic::parse_in_normalized(Language::English, &normalized).is_ok()
     }
 );
 
@@ -1433,6 +1431,22 @@ mod tests {
         );
         let oversized = "abandon ".repeat(81);
         assert_eq!(render(&format!(r#"{{{{ {oversized:?} | bip39_valid }}}}"#)), "false");
+    }
+
+    #[test]
+    fn bip39_valid_filter_is_boolean_in_conditionals() {
+        assert_eq!(
+            render(
+                r#"{% assign valid = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about" | bip39_valid %}{% if valid %}valid{% else %}invalid{% endif %}"#
+            ),
+            "valid"
+        );
+        assert_eq!(
+            render(
+                r#"{% assign valid = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon" | bip39_valid %}{% if valid %}valid{% else %}invalid{% endif %}"#
+            ),
+            "invalid"
+        );
     }
 
     #[test]

--- a/crates/kingfisher-rules/src/liquid_filters.rs
+++ b/crates/kingfisher-rules/src/liquid_filters.rs
@@ -1,6 +1,7 @@
 //! Collection of small Liquid filters that make HTTP validations & API-signing templates easy
 
 use base64::{Engine, engine::general_purpose};
+use bip39::{Language, Mnemonic};
 use crc32fast::Hasher;
 use hmac::{Hmac, KeyInit, Mac};
 use liquid_core::{
@@ -17,6 +18,7 @@ use time::{
     format_description::well_known::{Iso8601, Rfc2822},
 };
 use uuid::Uuid;
+use zeroize::Zeroizing;
 
 // -----------------------------------------------------------------------------
 // Helper macro – keeps most filters <10 lines long
@@ -521,6 +523,26 @@ static_filter!(
     /// a literal newline in the template would break indentation.
     NewlineFilter, "newline",
     |_input: &dyn ValueView| -> String { "\n".to_string() }
+);
+
+// {{ TOKEN | bip39_valid }}
+static_filter!(
+    /// Return whether the input is a checksum-valid English BIP-39 mnemonic.
+    Bip39ValidFilter, "bip39_valid",
+    |input: &dyn ValueView| -> String {
+        const MAX_MNEMONIC_BYTES: usize = 640;
+        let input = input.to_kstr();
+        if input.len() > MAX_MNEMONIC_BYTES {
+            return "false".to_string();
+        }
+
+        // This contains the full mnemonic. Keep `Zeroizing`: the crypto-inventory Semgrep rule
+        // flags the crate generically, but wiping this temporary is intentional memory hygiene.
+        let normalized = Zeroizing::new(input.split_whitespace().collect::<Vec<_>>().join(" "));
+        Mnemonic::parse_in_normalized(Language::English, &normalized)
+            .is_ok()
+            .to_string()
+    }
 );
 
 // -----------------------------------------------------------------------------
@@ -1100,6 +1122,7 @@ pub fn register_all(builder: liquid::ParserBuilder) -> liquid::ParserBuilder {
         .filter(IsoTimestampNoFracFilter)
         .filter(Rfc1123DateFilter)
         .filter(UuidFilter)
+        .filter(Bip39ValidFilter)
         .filter(JwtHeaderFilter)
         .filter(B64EncFilter)
         .filter(B64DecFilter)
@@ -1382,6 +1405,34 @@ mod tests {
                 .unwrap();
         let v = render(r#"{{ "" | uuid }}"#);
         assert!(uuid_re.is_match(&v));
+    }
+
+    #[test]
+    fn bip39_valid_filter_accepts_standard_lengths_and_whitespace() {
+        for phrase in [
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon address",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon admit",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+        ] {
+            assert_eq!(render(&format!(r#"{{{{ {phrase:?} | bip39_valid }}}}"#)), "true");
+        }
+
+        let spaced = "abandon  abandon\tabandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        assert_eq!(render(&format!(r#"{{{{ "{spaced}" | bip39_valid }}}}"#)), "true");
+    }
+
+    #[test]
+    fn bip39_valid_filter_rejects_bad_checksum_and_oversized_input() {
+        assert_eq!(
+            render(
+                r#"{{ "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon" | bip39_valid }}"#
+            ),
+            "false"
+        );
+        let oversized = "abandon ".repeat(81);
+        assert_eq!(render(&format!(r#"{{{{ {oversized:?} | bip39_valid }}}}"#)), "false");
     }
 
     #[test]

--- a/crates/kingfisher-rules/src/rule.rs
+++ b/crates/kingfisher-rules/src/rule.rs
@@ -76,9 +76,20 @@ pub enum Validation {
     Postgres,
     Jdbc,
     JWT,
+    /// Deterministic, network-free Ethereum key-material validation.
+    Ethereum(EthereumValidation),
     Raw(String),
     Http(HttpValidation),
     Grpc(GrpcValidation),
+}
+
+/// Ethereum key material that can be validated and mapped to a public address locally.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum EthereumValidation {
+    PrivateKey,
+    PublicKey,
+    Mnemonic,
 }
 
 /// Represents revocation actions that a rule can perform.

--- a/crates/kingfisher-scanner/Cargo.toml
+++ b/crates/kingfisher-scanner/Cargo.toml
@@ -43,6 +43,15 @@ validation-raw = [
     "dep:ldap3",
 ]
 
+# Deterministic, network-free Ethereum key parsing and address derivation.
+validation-ethereum = [
+    "dep:bip32",
+    "dep:bip39",
+    "dep:hex",
+    "dep:sha3",
+    "dep:zeroize",
+]
+
 # AWS credential validation
 validation-aws = [
     "validation-http",
@@ -112,6 +121,7 @@ validation-database = [
 validation-all = [
     "validation",
     "validation-raw",
+    "validation-ethereum",
     "validation-aws",
     "validation-azure",
     "validation-coinbase",
@@ -165,6 +175,12 @@ base64.workspace = true
 tracing.workspace = true
 
 # ---- Optional validation dependencies ----
+
+# Local Ethereum key-material validation
+bip32 = { workspace = true, optional = true }
+bip39 = { workspace = true, optional = true }
+sha3 = { workspace = true, optional = true }
+zeroize = { workspace = true, optional = true }
 
 # HTTP validation
 reqwest = { version = "0.13", default-features = false, features = [

--- a/crates/kingfisher-scanner/src/lib.rs
+++ b/crates/kingfisher-scanner/src/lib.rs
@@ -48,6 +48,7 @@
 //!
 //! - **validation**: Enable credential validation support
 //! - **validation-http**: HTTP-based validation (included in `validation`)
+//! - **validation-ethereum**: Network-free Ethereum key parsing and address derivation
 //! - **validation-aws**: AWS credential validation via STS
 //! - **validation-all**: Enable all validation features
 
@@ -67,6 +68,7 @@ mod scanner_pool;
     feature = "validation-gcp",
     feature = "validation-jwt",
     feature = "validation-database",
+    feature = "validation-ethereum",
     feature = "validation-all",
 ))]
 pub mod validation;

--- a/crates/kingfisher-scanner/src/validation/ethereum.rs
+++ b/crates/kingfisher-scanner/src/validation/ethereum.rs
@@ -1,0 +1,322 @@
+//! Deterministic, network-free validation of Ethereum key material.
+
+use bip32::{
+    DerivationPath, XPrv,
+    secp256k1::ecdsa::{SigningKey, VerifyingKey},
+};
+use bip39::{Language, Mnemonic};
+use kingfisher_core::ValidationOutcome;
+use kingfisher_rules::EthereumValidation;
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Keccak256};
+use zeroize::{Zeroize, Zeroizing};
+
+const DEFAULT_DERIVATION_PATH: &str = "m/44'/60'/0'/0/0";
+const MAX_MNEMONIC_BYTES: usize = 640;
+
+/// Secret-free result from local Ethereum validation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EthereumValidationOutcome {
+    pub outcome: ValidationOutcome,
+    pub body: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct DerivedAddressEvidence {
+    validation: String,
+    derived_address: String,
+    derivation: String,
+    key_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bip39_passphrase_assumption: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    derivation_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    derived_address_status: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct InvalidMaterialEvidence {
+    validation: String,
+}
+
+/// Parse key material and derive its EIP-55 address without network access.
+pub fn validate(kind: EthereumValidation, token: &str) -> EthereumValidationOutcome {
+    match kind {
+        EthereumValidation::PrivateKey => validate_private_key(token),
+        EthereumValidation::PublicKey => validate_public_key(token),
+        EthereumValidation::Mnemonic => validate_mnemonic(token),
+    }
+}
+
+/// Reconstruct an allowlisted, secret-free response for reports.
+pub fn sanitized_report_body(
+    kind: EthereumValidation,
+    outcome: ValidationOutcome,
+    body: &str,
+) -> Option<String> {
+    match outcome {
+        ValidationOutcome::LocallyDerived => {
+            let evidence: DerivedAddressEvidence = serde_json::from_str(body).ok()?;
+            let expected_key_type = match kind {
+                EthereumValidation::PrivateKey => "secp256k1_private_key",
+                EthereumValidation::PublicKey => "secp256k1_public_key",
+                EthereumValidation::Mnemonic => "bip39_mnemonic",
+            };
+            if evidence.validation != "cryptographically_valid_key_material"
+                || evidence.derivation != "local"
+                || evidence.key_type != expected_key_type
+                || !is_checksummed_address(&evidence.derived_address)
+            {
+                return None;
+            }
+
+            let metadata_is_valid = match kind {
+                EthereumValidation::Mnemonic => {
+                    evidence.bip39_passphrase_assumption.as_deref() == Some("empty")
+                        && evidence.derivation_path.as_deref() == Some(DEFAULT_DERIVATION_PATH)
+                        && evidence.derived_address_status.as_deref() == Some("candidate")
+                }
+                EthereumValidation::PrivateKey | EthereumValidation::PublicKey => {
+                    evidence.bip39_passphrase_assumption.is_none()
+                        && evidence.derivation_path.is_none()
+                        && evidence.derived_address_status.is_none()
+                }
+            };
+            metadata_is_valid.then(|| serde_json::to_string(&evidence).ok()).flatten()
+        }
+        ValidationOutcome::InvalidMaterial => {
+            let evidence: InvalidMaterialEvidence = serde_json::from_str(body).ok()?;
+            (evidence.validation == "invalid_key_material")
+                .then(|| serde_json::to_string(&evidence).ok())
+                .flatten()
+        }
+        _ => None,
+    }
+}
+
+fn validate_private_key(token: &str) -> EthereumValidationOutcome {
+    parse_private_key(token).map_or_else(invalid_key_material, |key| {
+        valid_outcome(address_from_public_key(key.verifying_key()), "secp256k1_private_key", false)
+    })
+}
+
+fn validate_public_key(token: &str) -> EthereumValidationOutcome {
+    parse_public_key(token).map_or_else(invalid_key_material, |key| {
+        valid_outcome(address_from_public_key(&key), "secp256k1_public_key", false)
+    })
+}
+
+fn validate_mnemonic(token: &str) -> EthereumValidationOutcome {
+    if token.len() > MAX_MNEMONIC_BYTES {
+        return invalid_key_material();
+    }
+
+    let normalized = Zeroizing::new(token.split_whitespace().collect::<Vec<_>>().join(" "));
+    let Some(mnemonic) = Mnemonic::parse_in_normalized(Language::English, &normalized).ok() else {
+        return invalid_key_material();
+    };
+
+    let mut seed = Zeroizing::new(mnemonic.to_seed_normalized(""));
+    let derived = DEFAULT_DERIVATION_PATH
+        .parse::<DerivationPath>()
+        .ok()
+        .and_then(|path| XPrv::derive_from_path(seed.as_slice(), &path).ok());
+    seed.as_mut().zeroize();
+
+    derived.map_or_else(invalid_key_material, |key| {
+        valid_outcome(
+            address_from_public_key(key.private_key().verifying_key()),
+            "bip39_mnemonic",
+            true,
+        )
+    })
+}
+
+fn parse_private_key(token: &str) -> Option<SigningKey> {
+    let encoded = strip_hex_prefix(token.trim());
+    if encoded.len() != 64 {
+        return None;
+    }
+    let mut bytes = Zeroizing::new([0_u8; 32]);
+    hex::decode_to_slice(encoded, bytes.as_mut()).ok()?;
+    SigningKey::from_slice(bytes.as_ref()).ok()
+}
+
+fn parse_public_key(token: &str) -> Option<VerifyingKey> {
+    let encoded = strip_hex_prefix(token.trim());
+    match encoded.len() {
+        128 => {
+            let mut bytes = [0_u8; 65];
+            bytes[0] = 0x04;
+            hex::decode_to_slice(encoded, &mut bytes[1..]).ok()?;
+            VerifyingKey::from_sec1_bytes(&bytes).ok()
+        }
+        66 if matches!(encoded.get(..2), Some("02" | "03")) => {
+            let bytes = hex::decode(encoded).ok()?;
+            VerifyingKey::from_sec1_bytes(&bytes).ok()
+        }
+        130 if encoded.starts_with("04") => {
+            let bytes = hex::decode(encoded).ok()?;
+            VerifyingKey::from_sec1_bytes(&bytes).ok()
+        }
+        _ => None,
+    }
+}
+
+fn strip_hex_prefix(value: &str) -> &str {
+    value.strip_prefix("0x").or_else(|| value.strip_prefix("0X")).unwrap_or(value)
+}
+
+fn address_from_public_key(key: &VerifyingKey) -> String {
+    let encoded = key.to_encoded_point(false);
+    let digest = Keccak256::digest(&encoded.as_bytes()[1..]);
+    checksum_address(&digest[12..])
+}
+
+fn checksum_address(address: &[u8]) -> String {
+    debug_assert_eq!(address.len(), 20);
+    let lower = hex::encode(address);
+    let hash = Keccak256::digest(lower.as_bytes());
+    let mut result = String::with_capacity(42);
+    result.push_str("0x");
+    for (index, byte) in lower.bytes().enumerate() {
+        let nibble = if index % 2 == 0 { hash[index / 2] >> 4 } else { hash[index / 2] & 0x0f };
+        if byte.is_ascii_alphabetic() && nibble >= 8 {
+            result.push((byte as char).to_ascii_uppercase());
+        } else {
+            result.push(byte as char);
+        }
+    }
+    result
+}
+
+fn is_checksummed_address(value: &str) -> bool {
+    let Some(encoded) = value.strip_prefix("0x") else {
+        return false;
+    };
+    if encoded.len() != 40 {
+        return false;
+    }
+    let Ok(bytes) = hex::decode(encoded) else {
+        return false;
+    };
+    checksum_address(&bytes) == value
+}
+
+fn valid_outcome(
+    derived_address: String,
+    key_type: &str,
+    is_mnemonic: bool,
+) -> EthereumValidationOutcome {
+    let evidence = DerivedAddressEvidence {
+        validation: "cryptographically_valid_key_material".to_string(),
+        derived_address,
+        derivation: "local".to_string(),
+        key_type: key_type.to_string(),
+        bip39_passphrase_assumption: is_mnemonic.then(|| "empty".to_string()),
+        derivation_path: is_mnemonic.then(|| DEFAULT_DERIVATION_PATH.to_string()),
+        derived_address_status: is_mnemonic.then(|| "candidate".to_string()),
+    };
+    EthereumValidationOutcome {
+        outcome: ValidationOutcome::LocallyDerived,
+        body: serde_json::to_string(&evidence).expect("fixed local evidence must serialize"),
+    }
+}
+
+fn invalid_key_material() -> EthereumValidationOutcome {
+    EthereumValidationOutcome {
+        outcome: ValidationOutcome::InvalidMaterial,
+        body: serde_json::to_string(&InvalidMaterialEvidence {
+            validation: "invalid_key_material".to_string(),
+        })
+        .expect("fixed local evidence must serialize"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ANVIL_PRIVATE_KEY: &str =
+        "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    const ANVIL_MNEMONIC: &str = "test test test test test test test test test test test junk";
+    const ANVIL_ADDRESS: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+    #[test]
+    fn private_key_derives_expected_address_without_echoing_secret() {
+        let outcome = validate(EthereumValidation::PrivateKey, ANVIL_PRIVATE_KEY);
+        assert_valid_address(&outcome, ANVIL_ADDRESS);
+        assert!(!outcome.body.contains(ANVIL_PRIVATE_KEY));
+    }
+
+    #[test]
+    fn public_key_encodings_derive_the_expected_address() {
+        for key in [
+            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+            "0x0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+            "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        ] {
+            assert_valid_address(
+                &validate(EthereumValidation::PublicKey, key),
+                "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_scalars_and_curve_points_are_rejected() {
+        for (kind, invalid) in [
+            (EthereumValidation::PrivateKey, "0".repeat(64)),
+            (EthereumValidation::PrivateKey, "f".repeat(64)),
+            (EthereumValidation::PublicKey, format!("02{}", "f".repeat(64))),
+            (EthereumValidation::PublicKey, format!("04{}", "0".repeat(128))),
+        ] {
+            let outcome = validate(kind, &invalid);
+            assert_eq!(outcome.outcome, ValidationOutcome::InvalidMaterial);
+            assert!(!outcome.body.contains(&invalid));
+        }
+    }
+
+    #[test]
+    fn mnemonic_derivation_records_its_assumptions() {
+        let outcome = validate(EthereumValidation::Mnemonic, ANVIL_MNEMONIC);
+        assert_valid_address(&outcome, ANVIL_ADDRESS);
+        let body: serde_json::Value = serde_json::from_str(&outcome.body).unwrap();
+        assert_eq!(body["derivation_path"], DEFAULT_DERIVATION_PATH);
+        assert_eq!(body["bip39_passphrase_assumption"], "empty");
+        assert_eq!(body["derived_address_status"], "candidate");
+        assert!(!outcome.body.contains(ANVIL_MNEMONIC));
+    }
+
+    #[test]
+    fn report_evidence_is_strictly_allowlisted() {
+        let outcome = validate(EthereumValidation::PrivateKey, ANVIL_PRIVATE_KEY);
+        assert_eq!(
+            sanitized_report_body(
+                EthereumValidation::PrivateKey,
+                ValidationOutcome::LocallyDerived,
+                &outcome.body,
+            ),
+            Some(outcome.body.clone())
+        );
+        let mut unsafe_body: serde_json::Value = serde_json::from_str(&outcome.body).unwrap();
+        unsafe_body["private_key"] = serde_json::Value::String(ANVIL_PRIVATE_KEY.to_string());
+        assert!(
+            sanitized_report_body(
+                EthereumValidation::PrivateKey,
+                ValidationOutcome::LocallyDerived,
+                &unsafe_body.to_string(),
+            )
+            .is_none()
+        );
+    }
+
+    fn assert_valid_address(outcome: &EthereumValidationOutcome, expected: &str) {
+        assert_eq!(outcome.outcome, ValidationOutcome::LocallyDerived);
+        let body: serde_json::Value = serde_json::from_str(&outcome.body).unwrap();
+        assert_eq!(body["derived_address"], expected);
+    }
+}

--- a/crates/kingfisher-scanner/src/validation/mod.rs
+++ b/crates/kingfisher-scanner/src/validation/mod.rs
@@ -22,9 +22,13 @@
 //! - **JWT**: JWT token validation (requires `validation-jwt` feature)
 //! - **Raw**: provider/protocol-specific validators that need custom logic
 //!   (requires `validation-raw` feature)
+//! - **Ethereum**: network-free key parsing and address derivation
+//!   (requires `validation-ethereum` feature)
 
 mod utils;
 mod validation_body;
+
+use kingfisher_core::ValidationOutcome;
 
 #[cfg(feature = "validation-http")]
 pub mod http_validation;
@@ -56,6 +60,9 @@ pub mod mysql;
 #[cfg(feature = "validation-database")]
 pub mod postgres;
 
+#[cfg(feature = "validation-ethereum")]
+pub mod ethereum;
+
 #[cfg(feature = "validation-raw")]
 pub mod raw;
 
@@ -84,8 +91,10 @@ pub use aws::{
     validate_aws_credentials, validate_aws_credentials_input,
 };
 
+#[cfg(feature = "validation-http")]
+use std::sync::{LazyLock, OnceLock};
 use std::{
-    sync::{Arc, LazyLock, OnceLock},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -144,6 +153,8 @@ pub struct CachedResponse {
     pub status: http::StatusCode,
     /// Whether the credential was valid.
     pub is_valid: bool,
+    /// Semantic validation classification, including offline outcomes.
+    pub outcome: ValidationOutcome,
     /// When this result was cached.
     pub timestamp: Instant,
 }
@@ -151,7 +162,14 @@ pub struct CachedResponse {
 impl CachedResponse {
     /// Create a new cached response.
     pub fn new(body: ValidationResponseBody, status: http::StatusCode, is_valid: bool) -> Self {
-        Self { body, status, is_valid, timestamp: Instant::now() }
+        let outcome = ValidationOutcome::from_legacy(false, is_valid, status.as_u16());
+        Self { body, status, is_valid, outcome, timestamp: Instant::now() }
+    }
+
+    /// Override the inferred legacy outcome with an explicit semantic outcome.
+    pub fn with_outcome(mut self, outcome: ValidationOutcome) -> Self {
+        self.outcome = outcome;
+        self
     }
 
     /// Check if this cached response is still valid.

--- a/data/default/rule_cleanup/count_rules.py
+++ b/data/default/rule_cleanup/count_rules.py
@@ -22,6 +22,7 @@ except ModuleNotFoundError as exc:
 DEFAULT_RULES_DIR = (
     Path(__file__).resolve().parents[3] / "crates/kingfisher-rules/data/rules"
 )
+NON_LIVE_VALIDATION_TYPES = {"Assumed", "Ethereum"}
 
 
 def parse_args() -> argparse.Namespace:
@@ -110,11 +111,11 @@ def main() -> int:
 
             identifier = rule_identifier(rule, path, index)
             validation = rule.get("validation")
-            is_assumed = (
+            is_non_live = (
                 isinstance(validation, dict)
-                and validation.get("type") == "Assumed"
+                and validation.get("type") in NON_LIVE_VALIDATION_TYPES
             )
-            if validation and not is_assumed:
+            if validation and not is_non_live:
                 standalone_with_validator.append(identifier)
             else:
                 standalone_without_validator.append(identifier)

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,11 @@ description: "Kingfisher release history: new features, rules, bug fixes, and im
 
 All notable changes to this project will be documented in this file.
 
+## [v1.112.0]
+- Added offline Ethereum key/BIP-39 detection with explicit local-validation outcomes, inspired by [#468](https://github.com/mongodb/kingfisher/pull/468) from @audityourcontracts.
+- Hardened validation caching and panic handling to avoid secret exposure.
+- Fixed remote Git URL scans hanging with `--jobs 1`. [#469](https://github.com/mongodb/kingfisher/issues/469)
+
 ## [v1.111.0]
 - Reduced Git scan metadata memory usage by interning repeated committer names and email addresses.
 - Reduced peak memory during large scans by bounding Git delta caches per worker and streaming matcher chunks; `--jobs` now controls the scanner worker pool.

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -2,7 +2,7 @@
 title: Kingfisher — Open Source Secret Scanner with Live Validation
 description: >-
   Kingfisher is an open source secret scanner with live validation, blast radius
-  mapping, and credential revocation. 1,051 detection rules (516 with live validation),
+  mapping, and credential revocation. 1,089 detection rules (527 with live validation),
   plus a browser-based report viewer that also triages SARIF, Gitleaks, and TruffleHog output.
   Built in Rust by MongoDB.
 template: home.html

--- a/docs-site/docs/reference/architecture.md
+++ b/docs-site/docs/reference/architecture.md
@@ -115,7 +115,7 @@ flowchart LR
 - `src/parser.rs` and `src/parser/*`: parser-based context verification for language-aware matching, with handwritten lexers plus lightweight HTML and CSS parsers.
 - `src/scanner_pool.rs`: thread-local vectorscan `BlockScanner` pool, providing safe reuse of compiled pattern databases across scan threads.
 - `src/reporter.rs` and `src/reporter/*`: report rendering for pretty, JSON, BSON, TOON, SARIF, and HTML outputs, plus the data model used by the viewer.
-- `src/direct_validate.rs`: direct validation of a known secret without going through pattern matching. Supports HTTP, gRPC, plus schema-level typed validators such as AWS, AzureStorage, GCP, JDBC, MongoDB, MySQL, PostgreSQL, JWT, and Coinbase, and delegates ad-hoc `Raw` validators to `crates/kingfisher-scanner/src/validation/raw.rs`.
+- `src/direct_validate.rs`: direct validation of a known secret without going through pattern matching. Supports HTTP, gRPC, plus schema-level typed validators such as AWS, AzureStorage, Ethereum, GCP, JDBC, MongoDB, MySQL, PostgreSQL, JWT, and Coinbase, and delegates ad-hoc `Raw` validators to `crates/kingfisher-scanner/src/validation/raw.rs`.
 - `src/direct_revoke.rs`: direct revocation of a known secret without going through the scan pipeline. Uses Liquid templates for revocation configurations and supports multi-step HTTP revocation flows.
 - `src/access_map.rs` and `src/access_map/*`: standalone blast-radius mapping with 24 provider implementations including AWS, Azure, GCP, GitHub, GitLab, Slack, Bitbucket, Gitea, Hugging Face, Buildkite, Anthropic, OpenAI, and more.
 

--- a/docs-site/docs/reference/library.md
+++ b/docs-site/docs/reference/library.md
@@ -269,7 +269,7 @@ flowchart TD
 
 ### Loading Builtin Rules
 
-Kingfisher currently ships with 1,051 built-in rules for common secret types:
+Kingfisher currently ships with 1,089 built-in rules for common secret types:
 
 ```rust
 use kingfisher_rules::{get_builtin_rules, Confidence};

--- a/docs-site/docs/reference/library.md
+++ b/docs-site/docs/reference/library.md
@@ -40,6 +40,7 @@ The `kingfisher-scanner` crate supports optional validation features:
 | `validation` | Core validation support (includes HTTP validation) |
 | `validation-http` | HTTP-based validation for API tokens |
 | `validation-raw` | Provider/protocol-specific raw validation flows for `validation: type: Raw` rules |
+| `validation-ethereum` | Network-free Ethereum key parsing and EIP-55 address derivation |
 | `validation-aws` | AWS credential validation via STS GetCallerIdentity |
 | `validation-azure` | Azure storage credential validation |
 | `validation-coinbase` | Coinbase credential validation |
@@ -734,6 +735,7 @@ kingfisher-scanner = { git = "https://github.com/mongodb/kingfisher", features =
 | `validation` | Core validation support with HTTP validation |
 | `validation-http` | HTTP-based validation for API tokens |
 | `validation-raw` | Provider/protocol-specific raw validation flows for `validation: type: Raw` rules |
+| `validation-ethereum` | Network-free Ethereum key parsing and EIP-55 address derivation |
 | `validation-aws` | AWS credential validation via STS |
 | `validation-azure` | Azure storage credential validation |
 | `validation-coinbase` | Coinbase credential validation |
@@ -745,8 +747,10 @@ kingfisher-scanner = { git = "https://github.com/mongodb/kingfisher", features =
 `validation: type: Raw` is the ad-hoc validator path for provider-specific or protocol-specific checks that are not generic enough to become schema-level validator families. Typed validators such as `AWS`, `GCP`, `MongoDB`, and `JWT` remain separate validator kinds in the rule schema.
 
 `kingfisher_core::ValidationOutcome` provides the transport-independent result model used by
-Kingfisher reports: `VerifiedActive`, `Assumed`, `VerifiedInactive`, `Unavailable`, `Skipped`, and
-`NotAttempted`. The human-readable statuses for `VerifiedActive`, `Assumed`, and `Unavailable` are
+Kingfisher reports: `VerifiedActive`, `Assumed`, `LocallyDerived`, `InvalidMaterial`,
+`VerifiedInactive`, `Unavailable`, `Skipped`, and `NotAttempted`. `LocallyDerived` means a
+network-free cryptographic validator accepted key material and derived public metadata; it does
+not assert current activity or ownership. The human-readable statuses for `VerifiedActive`, `Assumed`, and `Unavailable` are
 **Active Credential**, **Assumed Valid (Not Live-Validated)**, and
 **Inconclusive Validation**, respectively. The assumed outcome is high-confidence static detection,
 not proof that a credential is currently usable.
@@ -759,12 +763,13 @@ Use the built-in predicates when selecting findings:
 use kingfisher_core::ValidationOutcome;
 
 let outcome = ValidationOutcome::Assumed;
-assert!(outcome.is_actionable());       // active or assumed-valid
+assert!(outcome.is_actionable());       // active, assumed-valid, or locally derived
 assert!(!outcome.is_verified_active()); // live validation was not performed
 ```
 
 Serde serializes the variants as stable snake-case values (`verified_active`, `assumed`,
-`verified_inactive`, `unavailable`, `skipped`, and `not_attempted`).
+`locally_derived`, `invalid_material`, `verified_inactive`, `unavailable`, `skipped`, and
+`not_attempted`).
 
 ### HTTP Validation Example
 

--- a/docs-site/docs/rules/builtin-rules.md
+++ b/docs-site/docs/rules/builtin-rules.md
@@ -1,13 +1,13 @@
 ---
 title: "Built-in Rules List"
-description: "Complete list of all 1051 built-in secret detection rules in Kingfisher. Searchable and filterable by provider, confidence level, and validation support."
+description: "Complete list of all 1089 built-in secret detection rules in Kingfisher. Searchable and filterable by provider, confidence level, and validation support."
 ---
 
 # Built-in Rules
 
-Kingfisher ships with **1051 detection rules** across **612 providers**
-(914 detectors + 137 dependent rules).
-Of these, **516** include live validation and **52** support direct revocation.
+Kingfisher ships with **1089 detection rules** across **620 providers**
+(948 detectors + 141 dependent rules).
+Of these, **527** include live validation and **52** support direct revocation.
 
 !!! tip "Search"
     Use the search box below to filter rules by provider name, rule ID, or confidence level.
@@ -540,6 +540,30 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Atlassian</td>
+<td>Atlassian Account Email</td>
+<td><code>kingfisher.atlassian.4</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Atlassian</td>
+<td>Atlassian Cloud API Token</td>
+<td><code>kingfisher.atlassian.5</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Atlassian</td>
+<td>Atlassian Connect Shared Secret</td>
+<td><code>kingfisher.atlassian.6</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
 <td>Auth</td>
 <td>HTTP Basic Authorization Header</td>
 <td><code>kingfisher.auth.1</code></td>
@@ -1028,6 +1052,22 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Bamboo</td>
+<td>Bamboo Data Center Personal Access Token</td>
+<td><code>kingfisher.bamboo.1</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Bamboo</td>
+<td>Bamboo Data Center Base URL</td>
+<td><code>kingfisher.bamboo.2</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
 <td>Baremetrics</td>
 <td>Baremetrics API Key</td>
 <td><code>kingfisher.baremetrics.1</code></td>
@@ -1060,6 +1100,14 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Bip39</td>
+<td>BIP-39 Seed Phrase</td>
+<td><code>kingfisher.bip39.1</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
 <td>Bitbucket</td>
 <td>Bitbucket Client ID</td>
 <td><code>kingfisher.bitbucket.1</code></td>
@@ -1073,6 +1121,30 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td><code>kingfisher.bitbucket.3</code></td>
 <td>Medium</td>
 <td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Bitbucket</td>
+<td>Bitbucket Cloud Access Token</td>
+<td><code>kingfisher.bitbucket.4</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Bitbucket</td>
+<td>Bitbucket Cloud App Password</td>
+<td><code>kingfisher.bitbucket.5</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Bitbucket</td>
+<td>Bitbucket Data Center HTTP Access Token</td>
+<td><code>kingfisher.bitbucket.6</code></td>
+<td>Medium</td>
+<td></td>
 <td></td>
 </tr>
 <tr>
@@ -1103,6 +1175,14 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td>Bitrise</td>
 <td>Bitrise Personal Access Token</td>
 <td><code>kingfisher.bitrise.1</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Bitwarden</td>
+<td>Bitwarden OAuth2 Client Secret</td>
+<td><code>kingfisher.bitwarden.1</code></td>
 <td>Medium</td>
 <td>Yes</td>
 <td></td>
@@ -1440,6 +1520,14 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td>CircleCI API Project Token</td>
 <td><code>kingfisher.circleci.2</code></td>
 <td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Circleci</td>
+<td>CircleCI API Project Token (Prefixed)</td>
+<td><code>kingfisher.circleci.3</code></td>
+<td>High</td>
 <td>Yes</td>
 <td></td>
 </tr>
@@ -2005,7 +2093,7 @@ Of these, **516** include live validation and **52** support direct revocation.
 </tr>
 <tr>
 <td>Databricks</td>
-<td>Databricks API token</td>
+<td>Databricks API Token (Version-Suffixed)</td>
 <td><code>kingfisher.databricks.1</code></td>
 <td>Medium</td>
 <td>Yes</td>
@@ -2013,7 +2101,7 @@ Of these, **516** include live validation and **52** support direct revocation.
 </tr>
 <tr>
 <td>Databricks</td>
-<td>Databricks API Token</td>
+<td>Databricks API Token (Unsuffixed)</td>
 <td><code>kingfisher.databricks.2</code></td>
 <td>Medium</td>
 <td>Yes</td>
@@ -2196,6 +2284,14 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Deno</td>
+<td>Deno Organization Token</td>
+<td><code>kingfisher.deno.2</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
 <td>Dependency Track</td>
 <td>Dependency-Track API Key</td>
 <td><code>kingfisher.dtrack.1</code></td>
@@ -2335,6 +2431,14 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td>Discord</td>
 <td>Discord Bot ID</td>
 <td><code>kingfisher.discord.3</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Discord</td>
+<td>Discord MFA Token</td>
+<td><code>kingfisher.discord.4</code></td>
 <td>Medium</td>
 <td></td>
 <td></td>
@@ -2676,6 +2780,14 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Elastic</td>
+<td>Elastic Cloud Serverless API Key</td>
+<td><code>kingfisher.elastic.3</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
 <td>Elasticemail</td>
 <td>Elastic Email API Key</td>
 <td><code>kingfisher.elasticemail.1</code></td>
@@ -2719,6 +2831,30 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td>Eraserio</td>
 <td>Eraser API Key</td>
 <td><code>kingfisher.eraser.1</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Ethereum</td>
+<td>Ethereum Private Key</td>
+<td><code>kingfisher.ethereum.1</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Ethereum</td>
+<td>Ethereum BIP-39 Seed Phrase</td>
+<td><code>kingfisher.ethereum.2</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Ethereum</td>
+<td>Ethereum Public Key (Public Identifier)</td>
+<td><code>kingfisher.ethereum.3</code></td>
 <td>Medium</td>
 <td>Yes</td>
 <td></td>
@@ -3108,6 +3244,30 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Gcp</td>
+<td>GCP Express Mode API Key</td>
+<td><code>kingfisher.gcp.4</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Gcp</td>
+<td>Google Cloud Storage HMAC Key</td>
+<td><code>kingfisher.gcp.5</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Gcp</td>
+<td>GCP Application Default Credentials</td>
+<td><code>kingfisher.gcp.6</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
 <td>Gemfury</td>
 <td>Gemfury Deploy or Push Token</td>
 <td><code>kingfisher.gemfury.1</code></td>
@@ -3493,7 +3653,7 @@ Of these, **516** include live validation and **52** support direct revocation.
 </tr>
 <tr>
 <td>Google</td>
-<td>Google Gemini API Key</td>
+<td>GCP API Key</td>
 <td><code>kingfisher.google.7</code></td>
 <td>Medium</td>
 <td>Yes</td>
@@ -3716,11 +3876,43 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Hashicorp</td>
+<td>Hashicorp Vault AppRole Role ID</td>
+<td><code>kingfisher.hashicorp.8</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Hashicorp</td>
+<td>Hashicorp Vault AppRole Secret ID</td>
+<td><code>kingfisher.hashicorp.9</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
 <td>Hcaptcha</td>
 <td>hCaptcha Site Verify Secret Key</td>
 <td><code>kingfisher.hcaptcha.1</code></td>
 <td>Medium</td>
 <td></td>
+<td></td>
+</tr>
+<tr>
+<td>Hcp</td>
+<td>HashiCorp Cloud Platform Client ID</td>
+<td><code>kingfisher.hcp.1</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Hcp</td>
+<td>HashiCorp Cloud Platform Client Secret</td>
+<td><code>kingfisher.hcp.2</code></td>
+<td>Medium</td>
+<td>Yes</td>
 <td></td>
 </tr>
 <tr>
@@ -5412,6 +5604,14 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Onepassword</td>
+<td>1Password Recovery Key</td>
+<td><code>kingfisher.1password.3</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
 <td>Onesignal</td>
 <td>OneSignal REST API Key</td>
 <td><code>kingfisher.onesignal.1</code></td>
@@ -5580,6 +5780,62 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Packagist</td>
+<td>Packagist API Key</td>
+<td><code>kingfisher.packagist.1</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Packagist</td>
+<td>Packagist API Secret</td>
+<td><code>kingfisher.packagist.2</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Packagist</td>
+<td>Packagist Repository URL</td>
+<td><code>kingfisher.packagist.3</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Packagist</td>
+<td>Packagist Organization Read Token</td>
+<td><code>kingfisher.packagist.4</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Packagist</td>
+<td>Packagist Organization Update Token</td>
+<td><code>kingfisher.packagist.5</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Packagist</td>
+<td>Packagist User Update Token</td>
+<td><code>kingfisher.packagist.6</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Packagist</td>
+<td>Packagist Conductor Update Token</td>
+<td><code>kingfisher.packagist.7</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
 <td>Paddle</td>
 <td>Paddle API Key</td>
 <td><code>kingfisher.paddle.1</code></td>
@@ -5672,7 +5928,7 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td>PEM-Encoded Private Key</td>
 <td><code>kingfisher.pem.1</code></td>
 <td>High</td>
-<td></td>
+<td>Yes</td>
 <td></td>
 </tr>
 <tr>
@@ -5680,7 +5936,7 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td>Base64-PEM-Encoded Private Key</td>
 <td><code>kingfisher.pem.2</code></td>
 <td>High</td>
-<td></td>
+<td>Yes</td>
 <td></td>
 </tr>
 <tr>
@@ -6052,6 +6308,14 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Postman</td>
+<td>Postman Collection Access Token</td>
+<td><code>kingfisher.postman.2</code></td>
+<td>Medium</td>
+<td>Yes</td>
+<td></td>
+</tr>
+<tr>
 <td>Postmark</td>
 <td>Postmark API Token</td>
 <td><code>kingfisher.postmark.1</code></td>
@@ -6096,7 +6360,7 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td>Contains encrypted RSA private key</td>
 <td><code>kingfisher.privkey.1</code></td>
 <td>High</td>
-<td></td>
+<td>Yes</td>
 <td></td>
 </tr>
 <tr>
@@ -6104,7 +6368,7 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td>Contains Private Key</td>
 <td><code>kingfisher.privkey.2</code></td>
 <td>High</td>
-<td></td>
+<td>Yes</td>
 <td></td>
 </tr>
 <tr>
@@ -6177,6 +6441,22 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td><code>kingfisher.pypi.1</code></td>
 <td>Medium</td>
 <td>Yes</td>
+<td></td>
+</tr>
+<tr>
+<td>Pyx</td>
+<td>Astral pyx User Key (v1)</td>
+<td><code>kingfisher.pyx.1</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Pyx</td>
+<td>Astral pyx User Key (v2)</td>
+<td><code>kingfisher.pyx.2</code></td>
+<td>Medium</td>
+<td></td>
 <td></td>
 </tr>
 <tr>
@@ -7204,6 +7484,14 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td></td>
 </tr>
 <tr>
+<td>Stripe</td>
+<td>Stripe Webhook Signing Secret</td>
+<td><code>kingfisher.stripe.3</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
 <td>Stytch</td>
 <td>Stytch Project ID</td>
 <td><code>kingfisher.stytch.1</code></td>
@@ -7463,6 +7751,22 @@ Of these, **516** include live validation and **52** support direct revocation.
 <td>Tigris</td>
 <td>Tigris Secret Access Key</td>
 <td><code>kingfisher.tigris.2</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Tink</td>
+<td>Google Tink Plaintext Keyset (JSON)</td>
+<td><code>kingfisher.tink.1</code></td>
+<td>Medium</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>Tink</td>
+<td>Google Tink Plaintext Keyset (Base64)</td>
+<td><code>kingfisher.tink.2</code></td>
 <td>Medium</td>
 <td></td>
 <td></td>

--- a/docs-site/docs/rules/overview.md
+++ b/docs-site/docs/rules/overview.md
@@ -182,7 +182,7 @@ Kingfisher supports these validation types:
 
 1. `Assumed`: a rule-level marker for secret material accepted with high confidence without live validation. It produces the `Assumed Valid (Not Live-Validated)` finding status and is included by the `actionable` filter, but not by the strict `active` filter. In colorized pretty output it uses the same bright color as an active credential but with a locked icon. It counts as skipped validation by default and as successful validation with the `actionable` filter.
 2. `Http` and `Grpc`: YAML-native validation flows. Prefer these first.
-3. Typed validators: schema-level validation families already modeled in the rule schema, such as `AWS`, `AzureStorage`, `Coinbase`, `GCP`, `MongoDB`, `MySQL`, `Postgres`, `Jdbc`, and `JWT`.
+3. Typed validators: schema-level validation families already modeled in the rule schema, such as `AWS`, `AzureStorage`, `Coinbase`, `Ethereum`, `GCP`, `MongoDB`, `MySQL`, `Postgres`, `Jdbc`, and `JWT`. `Ethereum` is deterministic and network-free; it validates key material and derives an address without claiming the address is active.
 4. Raw validators: provider-specific or protocol-specific exception paths dispatched through `validation: type: Raw`.
 
 Rules without a `validation` block produce `Not Attempted` findings. They are not treated as
@@ -210,6 +210,11 @@ validation:
 Use `Raw` only when the provider check cannot be expressed reliably with `Http` or `Grpc` and does not justify a new reusable validator family. Raw validator implementations live in `crates/kingfisher-scanner/src/validation/raw.rs`.
 
 Typed validators are safer and more reusable because the validator kind is part of the schema. `Raw` validators are string-dispatched; an unknown `content` name is reported as an unimplemented, unverified validation result. If you need a Rust-backed exception path for one provider, prefer `Raw`; reserve new typed validators for stable validation families that can be reused across rules.
+
+The Ethereum family uses `content: private_key`, `public_key`, or `mnemonic`. Mnemonics use the
+standard `m/44'/60'/0'/0/0` path and explicitly assume an empty BIP-39 passphrase, so the reported
+address is a candidate. Validation responses contain only allowlisted derivation metadata and never
+the private key or seed phrase.
 
 ## gRPC Validation (Grpc)
 
@@ -504,6 +509,7 @@ Below is the complete list of Liquid filters available in Kingfisher, along with
 | `b64dec`              | –                                            | Decodes a Base64 string.                                                                                        | `{{ "aGVsbG8=" \| b64dec }}`                                         |
 | `b64url_dec`          | –                                            | Decodes a URL-safe Base64 string (with or without padding).                                                     | `{{ "Kys_Pw" \| b64url_dec }}`                                       |
 | `sha256`              | –                                            | Computes the SHA-256 hex digest of the input.                                                                  | `{{ TOKEN \| sha256 }}`                                              |
+| `bip39_valid`         | –                                            | Returns `true` only for a checksum-valid English BIP-39 mnemonic; the temporary normalized phrase is wiped on drop. | `{{ MNEMONIC \| bip39_valid }}`                                  |
 | `crc32`               | –                                            | Computes the CRC32 checksum of the input and returns a decimal value. | `{{ TOKEN \| crc32 }}` |
 | `crc32_dec`           | `digits` (integer, optional)                 | Computes the CRC32 checksum and returns the last `digits` decimal characters (zero-padded). Defaults to the full value when omitted. | `{{ TOKEN \| crc32_dec: 6 }}` |
 | `crc32_hex`           | `digits` (integer, optional)                 | Computes the CRC32 checksum and returns the last `digits` hexadecimal characters (zero-padded). Defaults to the full value when omitted. | `{{ TOKEN \| crc32_hex: 8 }}` |

--- a/docs-site/docs/rules/overview.md
+++ b/docs-site/docs/rules/overview.md
@@ -13,7 +13,7 @@ A _rule_ in Kingfisher is a YAML document that describes how to detect and (opti
 
 This document explains how to write custom rules for Kingfisher using a YAML-based rule system. The rules define regular expressions to detect secrets in source code and other textual data, and they can include validation or revocation steps to confirm or invalidate the secret. By using a rules-based system, Kingfisher is highly extensible—new rules can be added or existing ones modified without changing the core code.
 
-Kingfisher currently bundles 1,051 rules: 914 standalone detectors and 137 dependent rules. Of the standalone detectors, 516 support live validation.
+Kingfisher currently bundles 1,089 rules: 948 standalone detectors and 141 dependent rules. Of the standalone detectors, 527 support live validation.
 
 ## 1. Rule Schema
 

--- a/docs-site/docs/usage/advanced.md
+++ b/docs-site/docs/usage/advanced.md
@@ -366,7 +366,7 @@ The cache key includes the resolved rule order, rule patterns, platform, cache f
 
 ## Custom Rules
 
-Kingfisher currently ships with 1,051 built-in rules, but you may want to add your own custom rules or modify existing detection to better suit your needs.
+Kingfisher currently ships with 1,089 built-in rules, but you may want to add your own custom rules or modify existing detection to better suit your needs.
 
 First, review [RULES.md](../rules/overview.md) to learn how to create custom Kingfisher rules.
 

--- a/docs-site/docs/usage/basic-scanning.md
+++ b/docs-site/docs/usage/basic-scanning.md
@@ -79,7 +79,7 @@ The available filters are:
 |---|---|
 | `all` | Every finding (default) |
 | `active` | `verified_active` only |
-| `actionable` | `verified_active` and `assumed` |
+| `actionable` | `verified_active`, `assumed`, and `locally_derived` |
 
 `--only-valid` is a compatibility alias for `--validation-filter active`. The two options are
 mutually exclusive; select `actionable` when both active and assumed-valid findings are required.
@@ -1560,9 +1560,9 @@ Scan Summary:
 
 | Counter | Description |
 | ------- | ----------- |
-| **Successful Validations** | Findings classified as `Active Credential`. With `--validation-filter actionable`, assumed-valid findings are also counted here so the total matches the actionable set. |
+| **Successful Validations** | Findings classified as `Active Credential`. With `--validation-filter actionable`, assumed-valid and locally-derived findings are also counted here so the total matches the actionable set. |
 | **Failed Validations** | Findings classified as `Inactive Credential`: the provider authoritatively rejected the credential. |
-| **Skipped Validations** | Findings classified as `Validation Skipped` or `Canary Token (Skipped)`, plus assumed-valid findings unless `--validation-filter actionable` is used. |
+| **Skipped Validations** | Findings classified as `Validation Skipped` or `Canary Token (Skipped)`, plus assumed-valid and locally-derived findings unless `--validation-filter actionable` is used. |
 
 These summary counters do not cover every validation status. In particular,
 `Inconclusive Validation` and `Not Attempted` remain visible on individual findings but do not
@@ -1576,6 +1576,8 @@ The ` |Validation....: ` line on a finding describes the semantic validation res
 | -------------- | ------------------------ | ------- |
 | **Active Credential** | `verified_active` | A live or cryptographic validator proved that the credential is usable. |
 | **Assumed Valid (Not Live-Validated)** | `assumed` | The rule identified secret material with high confidence without proving that the credential is currently usable. It is included by `actionable`, but not by `active`/`--only-valid`. |
+| **Locally Derived** | `locally_derived` | Network-free cryptographic validation accepted key material and derived public metadata. This proves structure, not current activity or ownership. It is included by `actionable`, but not by `active`/`--only-valid`. |
+| **Invalid Cryptographic Material** | `invalid_material` | Network-free parsing or curve validation rejected the captured material. |
 | **Inactive Credential** | `verified_inactive` | A live validator authoritatively rejected the credential. This is different from a network or provider outage. |
 | **Inconclusive Validation** | `unavailable` | Validation was attempted, but a timeout, rate limit, server error, validator panic, or similar condition prevented a conclusion. It is neither proof of activity nor proof of inactivity. |
 | **Validation Skipped** | `skipped` | Validation was intentionally not attempted because a dependency or other precondition was missing. |
@@ -1584,16 +1586,16 @@ The ` |Validation....: ` line on a finding describes the semantic validation res
 
 `--validation-filter active` (and its `--only-valid` compatibility alias) includes only
 `Active Credential` findings. The `actionable` filter additionally includes
-`Assumed Valid (Not Live-Validated)` and excludes every other outcome.
+`Assumed Valid (Not Live-Validated)` and `Locally Derived`, and excludes every other outcome.
 Use `all` to retain inconclusive, skipped, inactive, and not-attempted findings. `--only-valid` and
 `--validation-filter` cannot be combined.
 
 In colorized stdout, active credentials use `🔓`. High-confidence assumed-valid secrets use the
 same bright color with `🔒`; the icon and explicit status make their lack of live validation clear.
 
-Assumed-valid findings are counted as **Skipped Validations** by default because no live validation
-was attempted. With `--validation-filter actionable`, they instead count as **Successful
-Validations**, aligning the counter with the actionable output.
+Assumed-valid and locally-derived findings are counted as **Skipped Validations** by default because
+no live validation was attempted. With `--validation-filter actionable`, they instead count as
+**Successful Validations**, aligning the counter with the actionable output.
 
 ### Why Validations Are Skipped
 

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Kingfisher
 site_url: https://mongodb.github.io/kingfisher
 site_description: >-
-  Open source secret scanner with live validation. 1,051 detection rules,
+  Open source secret scanner with live validation. 1,089 detection rules,
   blast radius mapping, credential revocation, and a browser-based
   report viewer that also imports SARIF, Gitleaks, and TruffleHog output.
   Built in Rust by MongoDB.

--- a/docs-site/overrides/home.html
+++ b/docs-site/overrides/home.html
@@ -36,7 +36,7 @@
   <section class="kf-stats">
     <div class="kf-stats__inner md-grid">
       <div class="kf-stats__item">
-        <span class="kf-stats__number">1,051</span>
+        <span class="kf-stats__number">1,089</span>
         <span class="kf-stats__label">Detection Rules</span>
       </div>
       <div class="kf-stats__item">

--- a/docs-site/overrides/main.html
+++ b/docs-site/overrides/main.html
@@ -7,7 +7,7 @@
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "Kingfisher",
-    "description": "Open source secret scanner with live validation. 1,051 detection rules, blast radius mapping, and credential revocation.",
+    "description": "Open source secret scanner with live validation. 1,089 detection rules, blast radius mapping, and credential revocation.",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Linux, macOS, Windows",
     "license": "https://opensource.org/licenses/Apache-2.0",

--- a/docs-site/scripts/generate-rules-page.py
+++ b/docs-site/scripts/generate-rules-page.py
@@ -12,6 +12,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 RULES_DIR = REPO_ROOT / "crates" / "kingfisher-rules" / "data" / "rules"
 OUTPUT = REPO_ROOT / "docs-site" / "docs" / "rules" / "builtin-rules.md"
+NON_LIVE_VALIDATION_TYPES = {"Assumed", "Ethereum"}
 
 
 def load_rules():
@@ -58,6 +59,7 @@ def load_rules():
                     "id": rule_id,
                     "confidence": confidence,
                     "validates": has_validation,
+                    "validation_type": validation.get("type") if isinstance(validation, dict) else None,
                     "revokes": has_revocation,
                     "dependent": is_dependent,
                 })
@@ -70,7 +72,13 @@ def generate_markdown(rules):
     total = len(rules)
     detectors = sum(1 for r in rules if not r["dependent"])
     dependent = total - detectors
-    validated = sum(1 for r in rules if r["validates"] and not r["dependent"])
+    validated = sum(
+        1
+        for r in rules
+        if r["validates"]
+        and not r["dependent"]
+        and r["validation_type"] not in NON_LIVE_VALIDATION_TYPES
+    )
     revocable = sum(1 for r in rules if r["revokes"] and not r["dependent"])
     providers = len(set(r["provider"] for r in rules))
 

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -363,7 +363,7 @@ The cache key includes the resolved rule order, rule patterns, platform, cache f
 
 ## Custom Rules
 
-Kingfisher currently ships with 1,051 built-in rules, but you may want to add your own custom rules or modify existing detection to better suit your needs.
+Kingfisher currently ships with 1,089 built-in rules, but you may want to add your own custom rules or modify existing detection to better suit your needs.
 
 First, review [RULES.md](RULES.md) to learn how to create custom Kingfisher rules.
 

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -266,7 +266,7 @@ flowchart TD
 
 ### Loading Builtin Rules
 
-Kingfisher currently ships with 1,051 built-in rules for common secret types:
+Kingfisher currently ships with 1,089 built-in rules for common secret types:
 
 ```rust
 use kingfisher_rules::{get_builtin_rules, Confidence};

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -37,6 +37,7 @@ The `kingfisher-scanner` crate supports optional validation features:
 | `validation` | Core validation support (includes HTTP validation) |
 | `validation-http` | HTTP-based validation for API tokens |
 | `validation-raw` | Provider/protocol-specific raw validation flows for `validation: type: Raw` rules |
+| `validation-ethereum` | Network-free Ethereum key parsing and EIP-55 address derivation |
 | `validation-aws` | AWS credential validation via STS GetCallerIdentity |
 | `validation-azure` | Azure storage credential validation |
 | `validation-coinbase` | Coinbase credential validation |
@@ -731,6 +732,7 @@ kingfisher-scanner = { git = "https://github.com/mongodb/kingfisher", features =
 | `validation` | Core validation support with HTTP validation |
 | `validation-http` | HTTP-based validation for API tokens |
 | `validation-raw` | Provider/protocol-specific raw validation flows for `validation: type: Raw` rules |
+| `validation-ethereum` | Network-free Ethereum key parsing and EIP-55 address derivation |
 | `validation-aws` | AWS credential validation via STS |
 | `validation-azure` | Azure storage credential validation |
 | `validation-coinbase` | Coinbase credential validation |
@@ -742,8 +744,10 @@ kingfisher-scanner = { git = "https://github.com/mongodb/kingfisher", features =
 `validation: type: Raw` is the ad-hoc validator path for provider-specific or protocol-specific checks that are not generic enough to become schema-level validator families. Typed validators such as `AWS`, `GCP`, `MongoDB`, and `JWT` remain separate validator kinds in the rule schema.
 
 `kingfisher_core::ValidationOutcome` provides the transport-independent result model used by
-Kingfisher reports: `VerifiedActive`, `Assumed`, `VerifiedInactive`, `Unavailable`, `Skipped`, and
-`NotAttempted`. The human-readable statuses for `VerifiedActive`, `Assumed`, and `Unavailable` are
+Kingfisher reports: `VerifiedActive`, `Assumed`, `LocallyDerived`, `InvalidMaterial`,
+`VerifiedInactive`, `Unavailable`, `Skipped`, and `NotAttempted`. `LocallyDerived` means a
+network-free cryptographic validator accepted key material and derived public metadata; it does
+not assert current activity or ownership. The human-readable statuses for `VerifiedActive`, `Assumed`, and `Unavailable` are
 **Active Credential**, **Assumed Valid (Not Live-Validated)**, and
 **Inconclusive Validation**, respectively. The assumed outcome is high-confidence static detection,
 not proof that a credential is currently usable.
@@ -756,12 +760,13 @@ Use the built-in predicates when selecting findings:
 use kingfisher_core::ValidationOutcome;
 
 let outcome = ValidationOutcome::Assumed;
-assert!(outcome.is_actionable());       // active or assumed-valid
+assert!(outcome.is_actionable());       // active, assumed-valid, or locally derived
 assert!(!outcome.is_verified_active()); // live validation was not performed
 ```
 
 Serde serializes the variants as stable snake-case values (`verified_active`, `assumed`,
-`verified_inactive`, `unavailable`, `skipped`, and `not_attempted`).
+`locally_derived`, `invalid_material`, `verified_inactive`, `unavailable`, `skipped`, and
+`not_attempted`).
 
 ### HTTP Validation Example
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -179,7 +179,7 @@ Kingfisher supports these validation types:
 
 1. `Assumed`: a rule-level marker for secret material accepted with high confidence without live validation. It produces the `Assumed Valid (Not Live-Validated)` finding status and is included by the `actionable` filter, but not by the strict `active` filter. In colorized pretty output it uses the same bright color as an active credential but with a locked icon. It counts as skipped validation by default and as successful validation with the `actionable` filter.
 2. `Http` and `Grpc`: YAML-native validation flows. Prefer these first.
-3. Typed validators: schema-level validation families already modeled in the rule schema, such as `AWS`, `AzureStorage`, `Coinbase`, `GCP`, `MongoDB`, `MySQL`, `Postgres`, `Jdbc`, and `JWT`.
+3. Typed validators: schema-level validation families already modeled in the rule schema, such as `AWS`, `AzureStorage`, `Coinbase`, `Ethereum`, `GCP`, `MongoDB`, `MySQL`, `Postgres`, `Jdbc`, and `JWT`. `Ethereum` is deterministic and network-free; it validates key material and derives an address without claiming the address is active.
 4. Raw validators: provider-specific or protocol-specific exception paths dispatched through `validation: type: Raw`.
 
 Rules without a `validation` block produce `Not Attempted` findings. They are not treated as
@@ -207,6 +207,11 @@ validation:
 Use `Raw` only when the provider check cannot be expressed reliably with `Http` or `Grpc` and does not justify a new reusable validator family. Raw validator implementations live in `crates/kingfisher-scanner/src/validation/raw.rs`.
 
 Typed validators are safer and more reusable because the validator kind is part of the schema. `Raw` validators are string-dispatched; an unknown `content` name is reported as an unimplemented, unverified validation result. If you need a Rust-backed exception path for one provider, prefer `Raw`; reserve new typed validators for stable validation families that can be reused across rules.
+
+The Ethereum family uses `content: private_key`, `public_key`, or `mnemonic`. Mnemonics use the
+standard `m/44'/60'/0'/0/0` path and explicitly assume an empty BIP-39 passphrase, so the reported
+address is a candidate. Validation responses contain only allowlisted derivation metadata and never
+the private key or seed phrase.
 
 ## gRPC Validation (Grpc)
 
@@ -499,6 +504,7 @@ Below is the complete list of Liquid filters available in Kingfisher, along with
 | `b64dec`              | –                                            | Decodes a Base64 string.                                                                                        | `{{ "aGVsbG8=" \| b64dec }}`                                         |
 | `b64url_dec`          | –                                            | Decodes a URL-safe Base64 string (with or without padding).                                                     | `{{ "Kys_Pw" \| b64url_dec }}`                                       |
 | `sha256`              | –                                            | Computes the SHA-256 hex digest of the input.                                                                  | `{{ TOKEN \| sha256 }}`                                              |
+| `bip39_valid`         | –                                            | Returns `true` only for a checksum-valid English BIP-39 mnemonic; the temporary normalized phrase is wiped on drop. | `{{ MNEMONIC \| bip39_valid }}`                                  |
 | `crc32`               | –                                            | Computes the CRC32 checksum of the input and returns a decimal value. | `{{ TOKEN \| crc32 }}` |
 | `crc32_dec`           | `digits` (integer, optional)                 | Computes the CRC32 checksum and returns the last `digits` decimal characters (zero-padded). Defaults to the full value when omitted. | `{{ TOKEN \| crc32_dec: 6 }}` |
 | `crc32_hex`           | `digits` (integer, optional)                 | Computes the CRC32 checksum and returns the last `digits` hexadecimal characters (zero-padded). Defaults to the full value when omitted. | `{{ TOKEN \| crc32_hex: 8 }}` |

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -10,7 +10,7 @@ A _rule_ in Kingfisher is a YAML document that describes how to detect and (opti
 
 This document explains how to write custom rules for Kingfisher using a YAML-based rule system. The rules define regular expressions to detect secrets in source code and other textual data, and they can include validation or revocation steps to confirm or invalidate the secret. By using a rules-based system, Kingfisher is highly extensible—new rules can be added or existing ones modified without changing the core code.
 
-Kingfisher currently bundles 1,051 rules: 914 standalone detectors and 137 dependent rules. Of the standalone detectors, 516 support live validation.
+Kingfisher currently bundles 1,089 rules: 948 standalone detectors and 141 dependent rules. Of the standalone detectors, 527 support live validation.
 
 ## 1. Rule Schema
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -74,7 +74,7 @@ The available filters are:
 |---|---|
 | `all` | Every finding (default) |
 | `active` | `verified_active` only |
-| `actionable` | `verified_active` and `assumed` |
+| `actionable` | `verified_active`, `assumed`, and `locally_derived` |
 
 `--only-valid` is a compatibility alias for `--validation-filter active`. The two options are
 mutually exclusive; select `actionable` when both active and assumed-valid findings are required.
@@ -1555,9 +1555,9 @@ Scan Summary:
 
 | Counter | Description |
 | ------- | ----------- |
-| **Successful Validations** | Findings classified as `Active Credential`. With `--validation-filter actionable`, assumed-valid findings are also counted here so the total matches the actionable set. |
+| **Successful Validations** | Findings classified as `Active Credential`. With `--validation-filter actionable`, assumed-valid and locally-derived findings are also counted here so the total matches the actionable set. |
 | **Failed Validations** | Findings classified as `Inactive Credential`: the provider authoritatively rejected the credential. |
-| **Skipped Validations** | Findings classified as `Validation Skipped` or `Canary Token (Skipped)`, plus assumed-valid findings unless `--validation-filter actionable` is used. |
+| **Skipped Validations** | Findings classified as `Validation Skipped` or `Canary Token (Skipped)`, plus assumed-valid and locally-derived findings unless `--validation-filter actionable` is used. |
 
 These summary counters do not cover every validation status. In particular,
 `Inconclusive Validation` and `Not Attempted` remain visible on individual findings but do not
@@ -1571,6 +1571,8 @@ The ` |Validation....: ` line on a finding describes the semantic validation res
 | -------------- | ------------------------ | ------- |
 | **Active Credential** | `verified_active` | A live or cryptographic validator proved that the credential is usable. |
 | **Assumed Valid (Not Live-Validated)** | `assumed` | The rule identified secret material with high confidence without proving that the credential is currently usable. It is included by `actionable`, but not by `active`/`--only-valid`. |
+| **Locally Derived** | `locally_derived` | Network-free cryptographic validation accepted key material and derived public metadata. This proves structure, not current activity or ownership. It is included by `actionable`, but not by `active`/`--only-valid`. |
+| **Invalid Cryptographic Material** | `invalid_material` | Network-free parsing or curve validation rejected the captured material. |
 | **Inactive Credential** | `verified_inactive` | A live validator authoritatively rejected the credential. This is different from a network or provider outage. |
 | **Inconclusive Validation** | `unavailable` | Validation was attempted, but a timeout, rate limit, server error, validator panic, or similar condition prevented a conclusion. It is neither proof of activity nor proof of inactivity. |
 | **Validation Skipped** | `skipped` | Validation was intentionally not attempted because a dependency or other precondition was missing. |
@@ -1579,16 +1581,16 @@ The ` |Validation....: ` line on a finding describes the semantic validation res
 
 `--validation-filter active` (and its `--only-valid` compatibility alias) includes only
 `Active Credential` findings. The `actionable` filter additionally includes
-`Assumed Valid (Not Live-Validated)` and excludes every other outcome.
+`Assumed Valid (Not Live-Validated)` and `Locally Derived`, and excludes every other outcome.
 Use `all` to retain inconclusive, skipped, inactive, and not-attempted findings. `--only-valid` and
 `--validation-filter` cannot be combined.
 
 In colorized stdout, active credentials use `🔓`. High-confidence assumed-valid secrets use the
 same bright color with `🔒`; the icon and explicit status make their lack of live validation clear.
 
-Assumed-valid findings are counted as **Skipped Validations** by default because no live validation
-was attempted. With `--validation-filter actionable`, they instead count as **Successful
-Validations**, aligning the counter with the actionable output.
+Assumed-valid and locally-derived findings are counted as **Skipped Validations** by default because
+no live validation was attempted. With `--validation-filter actionable`, they instead count as
+**Successful Validations**, aligning the counter with the actionable output.
 
 ### Why Validations Are Skipped
 

--- a/docs/viewer/index.html
+++ b/docs/viewer/index.html
@@ -1508,7 +1508,9 @@
     }
     .status-badge.active { background: #ecfdf5; color: #15803d; }
     .status-badge.assumed { background: #eff6ff; color: #1d4ed8; }
+    .status-badge.local { background: #ecfeff; color: #0e7490; }
     .status-badge.inactive { background: #fef2f2; color: #b91c1c; }
+    .status-badge.invalid-material { background: #fff1f2; color: #be123c; }
     .status-badge.unknown { background: var(--surface-muted); color: var(--text-muted); }
 
     /* Finding detail snippet */
@@ -2593,7 +2595,9 @@
                     <option value="all" selected>All validation states</option>
                     <option value="active">Active Credential</option>
                     <option value="assumed">Assumed Valid (Not Live-Validated)</option>
+                    <option value="local">Locally Derived</option>
                     <option value="inactive">Inactive Credential</option>
+                    <option value="invalid_material">Invalid Cryptographic Material</option>
                     <option value="inconclusive">Inconclusive Validation</option>
                     <option value="not_attempted">Not Attempted</option>
                     <option value="canary">Canary Token (Skipped)</option>
@@ -3497,6 +3501,8 @@
         findings: normalizedFindings.length,
         active_findings: counts.active || 0,
         inactive_findings: counts.inactive || 0,
+        locally_derived_findings: counts.local || 0,
+        invalid_material_findings: counts.invalid_material || 0,
         unknown_validation_findings: counts.unknown || 0,
         access_map_identities: 0,
         confidence_level: toolName === "Gitleaks" ? "imported" : "imported",
@@ -4579,7 +4585,9 @@
         scanMetadata.summary = {
           findings: Number(reportSummary.findings || 0),
           active: Number(reportSummary.active_findings || 0),
+          locallyDerived: Number(reportSummary.locally_derived_findings || 0),
           inactive: Number(reportSummary.inactive_findings || 0),
+          invalidMaterial: Number(reportSummary.invalid_material_findings || 0),
           unknown: Number(reportSummary.unknown_validation_findings || 0),
           identities: Number(reportSummary.access_map_identities || 0),
           rulesApplied: Number(reportSummary.rules_applied || 0),
@@ -4789,8 +4797,12 @@
           return normalizedStatus === "active";
         } else if (validation === "assumed") {
           return normalizedStatus === "assumed";
+        } else if (validation === "local") {
+          return normalizedStatus === "local";
         } else if (validation === "inactive") {
           return normalizedStatus === "inactive";
+        } else if (validation === "invalid_material") {
+          return normalizedStatus === "invalid_material";
         } else if (validation === "inconclusive") {
           return normalizedStatus === "inconclusive";
         } else if (validation === "not_attempted") {
@@ -4904,6 +4916,18 @@
         return "inactive";
       }
 
+      if (normalized === "locally derived" || normalized === "locally_derived") {
+        return "local";
+      }
+
+      if (
+        normalized === "invalid cryptographic material" ||
+        normalized === "invalid material" ||
+        normalized === "invalid_material"
+      ) {
+        return "invalid_material";
+      }
+
       if (
         normalized === "inconclusive validation" ||
         normalized === "validation unavailable" ||
@@ -4931,11 +4955,26 @@
       return "unknown";
     }
 
+    function validationBadgeClass(normalizedStatus) {
+      if (
+        normalizedStatus === "active" ||
+        normalizedStatus === "assumed" ||
+        normalizedStatus === "inactive"
+      ) {
+        return normalizedStatus;
+      }
+      if (normalizedStatus === "local") return "local";
+      if (normalizedStatus === "invalid_material") return "invalid-material";
+      return "unknown";
+    }
+
     function calculateValidationCounts(list = findings) {
       const counts = {
         active: 0,
         assumed: 0,
+        local: 0,
         inactive: 0,
+        invalid_material: 0,
         inconclusive: 0,
         not_attempted: 0,
         canary: 0,
@@ -5235,7 +5274,9 @@
       const palette = {
         active: "#22c55e",
         assumed: "#3b82f6",
+        local: "#06b6d4",
         inactive: "#f97316",
+        invalid_material: "#e11d48",
         not_attempted: "#38bdf8",
         canary: "#a855f7",
         unknown: "#9ca3af",
@@ -5243,7 +5284,9 @@
       const dataPoints = [
         { key: "active", label: "Active", color: palette.active },
         { key: "assumed", label: "Assumed Valid", color: palette.assumed },
+        { key: "local", label: "Locally Derived", color: palette.local },
         { key: "inactive", label: "Inactive", color: palette.inactive },
+        { key: "invalid_material", label: "Invalid Material", color: palette.invalid_material },
         { key: "not_attempted", label: "Not Attempted", color: palette.not_attempted },
         { key: "canary", label: "Canary Token", color: palette.canary },
         { key: "unknown", label: "Unknown", color: palette.unknown },
@@ -5533,7 +5576,7 @@
         return;
       }
 
-      const statusOrder = { active: 0, assumed: 1, inconclusive: 2, inactive: 3, canary: 4, not_attempted: 5, unknown: 6 };
+      const statusOrder = { active: 0, assumed: 1, local: 2, inconclusive: 3, inactive: 4, invalid_material: 5, canary: 6, not_attempted: 7, unknown: 8 };
       let baseFindings =
         scope === "filtered" ? getFilteredSortedFindings().slice() : (Array.isArray(findings) ? findings.slice() : []);
       if (activeOnly) {
@@ -5552,8 +5595,8 @@
         const fb = b.finding || {};
         const keyA = normalizeValidationStatus(fa.validation && fa.validation.status ? fa.validation.status : "");
         const keyB = normalizeValidationStatus(fb.validation && fb.validation.status ? fb.validation.status : "");
-        const sa = statusOrder.hasOwnProperty(keyA) ? statusOrder[keyA] : 6;
-        const sb = statusOrder.hasOwnProperty(keyB) ? statusOrder[keyB] : 6;
+        const sa = statusOrder.hasOwnProperty(keyA) ? statusOrder[keyA] : statusOrder.unknown;
+        const sb = statusOrder.hasOwnProperty(keyB) ? statusOrder[keyB] : statusOrder.unknown;
         if (sa !== sb) return sa - sb;
 
         const ra = (a.rule && (a.rule.name || a.rule.id)) || "";
@@ -5995,14 +6038,7 @@
               ? String(finding.validation.status)
               : "Unknown";
           const normalizedStatus = normalizeValidationStatus(status);
-          const badgeClass =
-            normalizedStatus === "active"
-              ? "active"
-              : normalizedStatus === "assumed"
-                ? "assumed"
-              : normalizedStatus === "inactive"
-                ? "inactive"
-                : "unknown";
+          const badgeClass = validationBadgeClass(normalizedStatus);
 
           const enrichedChip = finding.kingfisher_enrichment
             ? `<span class="chip-enriched" title="Enriched with Kingfisher validation and revoke data">Enriched</span>`
@@ -6115,14 +6151,7 @@
       const statusRaw =
         finding.validation && finding.validation.status ? String(finding.validation.status) : "Unknown";
       const normalizedStatus = normalizeValidationStatus(statusRaw);
-      const badgeClass =
-        normalizedStatus === "active"
-          ? "active"
-          : normalizedStatus === "assumed"
-            ? "assumed"
-          : normalizedStatus === "inactive"
-            ? "inactive"
-            : "unknown";
+      const badgeClass = validationBadgeClass(normalizedStatus);
       const statusEl = document.getElementById("fd-validation-status");
       if (statusEl) {
         statusEl.innerHTML = `<span class="status-badge ${badgeClass}">${escapeHtml(statusRaw)}</span>`;
@@ -6310,7 +6339,7 @@
 
       const statusRaw = enr.validation && enr.validation.status ? String(enr.validation.status) : "Unknown";
       const normalized = normalizeValidationStatus(statusRaw);
-      const badgeClass = normalized === "active" ? "active" : normalized === "inactive" ? "inactive" : "unknown";
+      const badgeClass = validationBadgeClass(normalized);
       const validationEl = document.getElementById("fd-kf-validation");
       if (validationEl) {
         validationEl.innerHTML = `<span class="status-badge ${badgeClass}">${escapeHtml(statusRaw)}</span>`;
@@ -6753,14 +6782,14 @@
       }
 
       // Sort: active first, then by rule name
-      const statusOrder = { active: 0, inconclusive: 1, inactive: 2, canary: 3, not_attempted: 4, unknown: 5 };
+      const statusOrder = { active: 0, assumed: 1, local: 2, inconclusive: 3, inactive: 4, invalid_material: 5, canary: 6, not_attempted: 7, unknown: 8 };
       const sorted = pool.sort((a, b) => {
         const fa = a.finding || {};
         const fb = b.finding || {};
         const keyA = normalizeValidationStatus(fa.validation && fa.validation.status ? fa.validation.status : "");
         const keyB = normalizeValidationStatus(fb.validation && fb.validation.status ? fb.validation.status : "");
-        const sa = statusOrder.hasOwnProperty(keyA) ? statusOrder[keyA] : 6;
-        const sb = statusOrder.hasOwnProperty(keyB) ? statusOrder[keyB] : 6;
+        const sa = statusOrder.hasOwnProperty(keyA) ? statusOrder[keyA] : statusOrder.unknown;
+        const sb = statusOrder.hasOwnProperty(keyB) ? statusOrder[keyB] : statusOrder.unknown;
         if (sa !== sb) return sa - sb;
         const ra = (a.rule && (a.rule.name || a.rule.id)) || "";
         const rb = (b.rule && (b.rule.name || b.rule.id)) || "";

--- a/src/direct_validate.rs
+++ b/src/direct_validate.rs
@@ -12,6 +12,7 @@ use std::{
 
 use anyhow::{Context, Result, anyhow, bail};
 use crossbeam_skiplist::SkipMap;
+use kingfisher_core::ValidationOutcome;
 use liquid::Object;
 use liquid_core::{Value, ValueView};
 use reqwest::Client;
@@ -60,6 +61,10 @@ fn preview_body_for_display(body: &str, max_bytes: usize) -> String {
     format!("{}...", &body[..end])
 }
 
+fn outcome_from_validator_result(is_valid: bool) -> ValidationOutcome {
+    if is_valid { ValidationOutcome::VerifiedActive } else { ValidationOutcome::VerifiedInactive }
+}
+
 /// Result of a direct validation attempt.
 #[derive(Debug, Clone, Serialize)]
 pub struct DirectValidationResult {
@@ -67,9 +72,11 @@ pub struct DirectValidationResult {
     pub rule_id: String,
     /// The rule name.
     pub rule_name: String,
-    /// Whether the validator accepted the secret. For an assumed rule this is true even though no
-    /// live validation request was performed; inspect `message` for the explicit classification.
+    /// Whether a live validator accepted the secret. Assumed rules retain legacy `true`; local
+    /// derivation remains `false`. Use `validation_outcome` for the semantic classification.
     pub is_valid: bool,
+    /// Semantic validation classification. Local derivation is distinct from live validity.
+    pub validation_outcome: ValidationOutcome,
     /// HTTP status code from the validation request (if applicable).
     pub status_code: Option<u16>,
     /// Response body or error message.
@@ -133,6 +140,9 @@ fn extract_validation_vars(validation: &Validation) -> BTreeSet<String> {
 
     match validation {
         Validation::Assumed => {}
+        Validation::Ethereum(_) => {
+            vars.insert("TOKEN".to_string());
+        }
         Validation::Http(http) => {
             // Extract from URL
             vars.extend(extract_template_vars(&http.request.url));
@@ -356,6 +366,7 @@ async fn execute_http_validation(
         rule_id: String::new(), // Will be filled in by caller
         rule_name: String::new(),
         is_valid,
+        validation_outcome: ValidationOutcome::from_legacy(false, is_valid, status.as_u16()),
         status_code: Some(status.as_u16()),
         message: display_body,
     })
@@ -419,6 +430,7 @@ async fn execute_grpc_validation(
         rule_id: String::new(), // Will be filled in by caller
         rule_name: String::new(),
         is_valid,
+        validation_outcome: ValidationOutcome::from_legacy(false, is_valid, status.as_u16()),
         status_code: Some(status.as_u16()),
         message: display_body,
     })
@@ -614,9 +626,21 @@ pub async fn run_direct_validation(
                 rule_id: String::new(),
                 rule_name: String::new(),
                 is_valid: true,
+                validation_outcome: ValidationOutcome::Assumed,
                 status_code: None,
                 message: kingfisher_core::ValidationOutcome::Assumed.display_name().to_string(),
             },
+            Validation::Ethereum(kind) => {
+                let outcome = kingfisher_scanner::validation::ethereum::validate(*kind, &secret);
+                DirectValidationResult {
+                    rule_id: String::new(),
+                    rule_name: String::new(),
+                    is_valid: false,
+                    validation_outcome: outcome.outcome,
+                    status_code: None,
+                    message: outcome.body,
+                }
+            }
             Validation::Http(http_validation) => {
                 match execute_http_validation(
                     http_validation,
@@ -641,6 +665,7 @@ pub async fn run_direct_validation(
                             rule_id: rule_id.clone(),
                             rule_name: rule_name.clone(),
                             is_valid: false,
+                            validation_outcome: ValidationOutcome::Unavailable,
                             status_code: None,
                             message: "HTTP validation failed".to_string(),
                         }
@@ -664,6 +689,7 @@ pub async fn run_direct_validation(
                             rule_id: rule_id.clone(),
                             rule_name: rule_name.clone(),
                             is_valid: false,
+                            validation_outcome: ValidationOutcome::Unavailable,
                             status_code: None,
                             message: "gRPC validation failed".to_string(),
                         }
@@ -696,6 +722,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid,
+                        validation_outcome: outcome_from_validator_result(is_valid),
                         status_code: None,
                         message,
                     },
@@ -703,6 +730,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("AWS validation error: {}", e),
                     },
@@ -718,6 +746,7 @@ pub async fn run_direct_validation(
                                 rule_id: String::new(),
                                 rule_name: String::new(),
                                 is_valid,
+                                validation_outcome: outcome_from_validator_result(is_valid),
                                 status_code: None,
                                 message: if metadata.is_empty() {
                                     "GCP credential validation completed".to_string()
@@ -729,6 +758,7 @@ pub async fn run_direct_validation(
                                 rule_id: String::new(),
                                 rule_name: String::new(),
                                 is_valid: false,
+                                validation_outcome: ValidationOutcome::Unavailable,
                                 status_code: None,
                                 message: format!("GCP validation error: {}", e),
                             },
@@ -738,6 +768,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("Failed to initialize GCP validator: {}", e),
                     },
@@ -751,6 +782,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid,
+                        validation_outcome: outcome_from_validator_result(is_valid),
                         status_code: None,
                         message,
                     },
@@ -758,6 +790,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("MongoDB validation error: {}", e),
                     },
@@ -771,6 +804,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid,
+                        validation_outcome: outcome_from_validator_result(is_valid),
                         status_code: None,
                         message: if metadata.is_empty() {
                             "MySQL validation completed".to_string()
@@ -782,6 +816,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("MySQL validation error: {}", e),
                     },
@@ -795,6 +830,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid,
+                        validation_outcome: outcome_from_validator_result(is_valid),
                         status_code: None,
                         message: if metadata.is_empty() {
                             "Postgres validation completed".to_string()
@@ -806,6 +842,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("Postgres validation error: {}", e),
                     },
@@ -819,6 +856,11 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: outcome.valid,
+                        validation_outcome: ValidationOutcome::from_legacy(
+                            false,
+                            outcome.valid,
+                            outcome.status.as_u16(),
+                        ),
                         status_code: Some(outcome.status.as_u16()),
                         message: outcome.message,
                     },
@@ -826,6 +868,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("JDBC validation error: {}", e),
                     },
@@ -839,6 +882,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid,
+                        validation_outcome: outcome_from_validator_result(is_valid),
                         status_code: None,
                         message,
                     },
@@ -846,6 +890,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("JWT validation error: {}", e),
                     },
@@ -881,6 +926,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid,
+                        validation_outcome: outcome_from_validator_result(is_valid),
                         status_code: None,
                         message: validation_body::clone_as_string(&body),
                     },
@@ -888,6 +934,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("Azure Storage validation error: {}", e),
                     },
@@ -909,6 +956,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid,
+                        validation_outcome: outcome_from_validator_result(is_valid),
                         status_code: None,
                         message: validation_body::clone_as_string(&body),
                     },
@@ -916,6 +964,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("Coinbase validation error: {}", e),
                     },
@@ -936,6 +985,11 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: result.valid,
+                        validation_outcome: ValidationOutcome::from_legacy(
+                            false,
+                            result.valid,
+                            result.status.as_u16(),
+                        ),
                         status_code: Some(result.status.as_u16()),
                         message: result.body,
                     },
@@ -943,6 +997,7 @@ pub async fn run_direct_validation(
                         rule_id: String::new(),
                         rule_name: String::new(),
                         is_valid: false,
+                        validation_outcome: ValidationOutcome::Unavailable,
                         status_code: None,
                         message: format!("Raw validation error: {}", e),
                     },
@@ -1151,13 +1206,19 @@ pub fn print_results(results: &[DirectValidationResult], format: &str, use_color
                     println!(); // Separator between results
                 }
 
-                let is_high_confidence =
-                    result.message == kingfisher_core::ValidationOutcome::Assumed.display_name();
-                let valid_str = if is_high_confidence {
+                let valid_str = if result.validation_outcome == ValidationOutcome::Assumed {
                     if use_color {
                         "\x1b[94m🔒 Assumed Valid (Not Live-Validated)\x1b[0m"
                     } else {
                         "Assumed Valid (Not Live-Validated)"
+                    }
+                } else if result.validation_outcome == ValidationOutcome::LocallyDerived {
+                    if use_color { "\x1b[36m◇ LOCALLY DERIVED\x1b[0m" } else { "LOCALLY DERIVED" }
+                } else if result.validation_outcome == ValidationOutcome::InvalidMaterial {
+                    if use_color {
+                        "\x1b[31m✗ INVALID MATERIAL\x1b[0m"
+                    } else {
+                        "INVALID MATERIAL"
                     }
                 } else if result.is_valid {
                     if use_color { "\x1b[32m✓ VALID\x1b[0m" } else { "VALID" }
@@ -1180,7 +1241,7 @@ pub fn print_results(results: &[DirectValidationResult], format: &str, use_color
     }
 }
 
-/// Check if any result is valid.
-pub fn any_valid(results: &[DirectValidationResult]) -> bool {
-    results.iter().any(|r| r.is_valid)
+/// Check if any result produced an actionable validation outcome.
+pub fn any_actionable(results: &[DirectValidationResult]) -> bool {
+    results.iter().any(|r| r.validation_outcome.is_actionable())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1353,8 +1353,9 @@ async fn async_main(args: CommandLineArgs, matches: clap::ArgMatches) -> Result<
                 direct_validate::run_direct_validation(&validate_args, &global_args).await?;
             let use_color = global_args.use_color(std::io::stdout());
             direct_validate::print_results(&results, &validate_args.format, use_color);
-            // Exit with code 0 if any result is valid, 1 if all invalid
-            if direct_validate::any_valid(&results) {
+            // Offline local derivation is a successful validation operation even though it does
+            // not claim the material is an active credential.
+            if direct_validate::any_actionable(&results) {
                 Ok(AsyncMainOutcome::Done)
             } else {
                 std::process::exit(1);

--- a/src/matcher/conversion.rs
+++ b/src/matcher/conversion.rs
@@ -43,6 +43,12 @@ pub struct OwnedBlobMatch {
 impl OwnedBlobMatch {
     /// Refresh the semantic outcome after legacy validation fields change.
     pub fn refresh_validation_outcome(&mut self) {
+        if matches!(
+            self.validation_outcome,
+            ValidationOutcome::LocallyDerived | ValidationOutcome::InvalidMaterial
+        ) {
+            return;
+        }
         let assumed = matches!(
             self.rule.syntax().validation.as_ref(),
             Some(crate::rules::rule::Validation::Assumed)
@@ -180,6 +186,12 @@ pub struct Match {
 impl Match {
     /// Refresh the semantic outcome after applying a cached validation result.
     pub fn refresh_validation_outcome(&mut self) {
+        if matches!(
+            self.validation_outcome,
+            ValidationOutcome::LocallyDerived | ValidationOutcome::InvalidMaterial
+        ) {
+            return;
+        }
         let assumed = matches!(
             self.rule.syntax().validation.as_ref(),
             Some(crate::rules::rule::Validation::Assumed)

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -59,6 +59,9 @@ fn required_vars_for_validation(validation: &crate::rules::Validation) -> BTreeS
 
     match validation {
         Validation::Assumed => {}
+        Validation::Ethereum(_) => {
+            vars.insert("TOKEN".to_string());
+        }
         Validation::Http(http) => {
             vars.extend(extract_template_vars(&http.request.url));
             for (k, v) in &http.request.headers {
@@ -383,7 +386,7 @@ fn build_validate_command(
                 escape_for_shell(snippet)
             ))
         }
-        Validation::GCP => {
+        Validation::GCP | Validation::Ethereum(_) => {
             // GCP validation uses the service account JSON key
             Some(format!(
                 "kingfisher validate --rule {} {}{}",
@@ -959,9 +962,19 @@ impl DetailsReporter {
             rm.validation_outcome.display_name().to_string()
         };
 
-        let validation_body_str = validation_body::as_str(&rm.validation_response_body);
+        let raw_validation_body = validation_body::as_str(&rm.validation_response_body);
+        let sanitized_local_body = match rm.m.rule.syntax().validation.as_ref() {
+            Some(crate::rules::Validation::Ethereum(kind)) => {
+                kingfisher_scanner::validation::ethereum::sanitized_report_body(
+                    *kind,
+                    rm.validation_outcome,
+                    raw_validation_body,
+                )
+            }
+            _ => Some(raw_validation_body.to_string()),
+        };
         let response_body = format_validation_response(
-            validation_body_str,
+            sanitized_local_body.as_deref().unwrap_or_default(),
             args.redact,
             args.full_validation_response,
         );
@@ -1177,12 +1190,18 @@ impl DetailsReporter {
     ) -> ScanReportMetadata {
         let mut active_findings = 0usize;
         let mut inactive_findings = 0usize;
+        let mut locally_derived_findings = 0usize;
+        let mut invalid_material_findings = 0usize;
         let mut unknown_validation_findings = 0usize;
 
         for record in findings {
             match record.finding.validation.outcome {
                 kingfisher_core::ValidationOutcome::VerifiedActive => active_findings += 1,
                 kingfisher_core::ValidationOutcome::VerifiedInactive => inactive_findings += 1,
+                kingfisher_core::ValidationOutcome::LocallyDerived => locally_derived_findings += 1,
+                kingfisher_core::ValidationOutcome::InvalidMaterial => {
+                    invalid_material_findings += 1
+                }
                 _ => unknown_validation_findings += 1,
             }
         }
@@ -1215,6 +1234,8 @@ impl DetailsReporter {
                 findings: findings.len(),
                 active_findings,
                 inactive_findings,
+                locally_derived_findings,
+                invalid_material_findings,
                 unknown_validation_findings,
                 access_map_identities: access_map.map_or(0, Vec::len),
                 rules_applied: self.audit_context.as_ref().and_then(|ctx| ctx.rules_applied),
@@ -1596,6 +1617,8 @@ pub struct ScanReportSummary {
     pub findings: usize,
     pub active_findings: usize,
     pub inactive_findings: usize,
+    pub locally_derived_findings: usize,
+    pub invalid_material_findings: usize,
     pub unknown_validation_findings: usize,
     pub access_map_identities: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2065,6 +2088,8 @@ mod tests {
         let outcomes = [
             ValidationOutcome::VerifiedActive,
             ValidationOutcome::Assumed,
+            ValidationOutcome::LocallyDerived,
+            ValidationOutcome::InvalidMaterial,
             ValidationOutcome::VerifiedInactive,
             ValidationOutcome::Unavailable,
             ValidationOutcome::Skipped,
@@ -2091,14 +2116,14 @@ mod tests {
             validation_filter: cli::commands::scan::ValidationFilter::All,
             audit_context: None,
         };
-        assert_eq!(reporter.get_filtered_matches(false).unwrap().len(), 6);
+        assert_eq!(reporter.get_filtered_matches(false).unwrap().len(), 8);
 
         reporter.validation_filter = cli::commands::scan::ValidationFilter::Active;
         assert_eq!(reporter.get_filtered_matches(false).unwrap().len(), 1);
 
         reporter.validation_filter = cli::commands::scan::ValidationFilter::Actionable;
         let actionable = reporter.get_filtered_matches(false).unwrap();
-        assert_eq!(actionable.len(), 2);
+        assert_eq!(actionable.len(), 3);
         assert!(actionable.iter().all(|finding| finding.validation_outcome.is_actionable()));
     }
 

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -387,7 +387,7 @@ fn build_validate_command(
             ))
         }
         Validation::GCP | Validation::Ethereum(_) => {
-            // GCP validation uses the service account JSON key
+            // Both validators use the captured token directly.
             Some(format!(
                 "kingfisher validate --rule {} {}{}",
                 rule_id,
@@ -973,8 +973,10 @@ impl DetailsReporter {
             }
             _ => Some(raw_validation_body.to_string()),
         };
+        const SANITIZATION_FAILURE_PLACEHOLDER: &str =
+            "[validation response omitted: local evidence failed sanitization]";
         let response_body = format_validation_response(
-            sanitized_local_body.as_deref().unwrap_or_default(),
+            sanitized_local_body.as_deref().unwrap_or(SANITIZATION_FAILURE_PLACEHOLDER),
             args.redact,
             args.full_validation_response,
         );
@@ -2205,6 +2207,34 @@ mod tests {
 
         let record = reporter.build_finding_record(&report_match, &sample_scan_args());
         assert_eq!(record.finding.validation.status, "Inconclusive Validation");
+    }
+
+    #[test]
+    fn malformed_local_evidence_uses_safe_placeholder() {
+        let temp = tempdir().unwrap();
+        let datastore =
+            Arc::new(Mutex::new(findings_store::FindingsStore::new(temp.path().to_path_buf())));
+        let reporter = DetailsReporter {
+            datastore,
+            styles: Styles::new(false),
+            validation_filter: cli::commands::scan::ValidationFilter::All,
+            audit_context: None,
+        };
+
+        let (mut report_match, _) = sample_report_match("{}", StatusCode::OK.as_u16(), false);
+        Arc::get_mut(&mut report_match.m.rule)
+            .expect("sample rule must be uniquely owned")
+            .syntax
+            .validation = Some(crate::rules::Validation::Ethereum(
+            crate::rules::rule::EthereumValidation::PrivateKey,
+        ));
+        report_match.validation_outcome = kingfisher_core::ValidationOutcome::LocallyDerived;
+
+        let record = reporter.build_finding_record(&report_match, &sample_scan_args());
+        assert_eq!(
+            record.finding.validation.response,
+            "[validation response omitted: local evidence failed sanitization]"
+        );
     }
 
     #[test]

--- a/src/reporter/html_format.rs
+++ b/src/reporter/html_format.rs
@@ -67,9 +67,11 @@ fn render_metadata(metadata: &ScanReportMetadata) -> String {
     lines.push(summary_line(
         "Validation Split",
         &format!(
-            "Active {} | Inactive {} | Unknown {}",
+            "Active {} | Local {} | Inactive {} | Invalid material {} | Unknown {}",
             metadata.summary.active_findings,
+            metadata.summary.locally_derived_findings,
             metadata.summary.inactive_findings,
+            metadata.summary.invalid_material_findings,
             metadata.summary.unknown_validation_findings
         ),
     ));
@@ -98,18 +100,22 @@ fn validation_rank(status: &str) -> usize {
         0
     } else if status.eq_ignore_ascii_case("Assumed Valid (Not Live-Validated)") {
         1
-    } else if status.eq_ignore_ascii_case("Inconclusive Validation") {
+    } else if status.eq_ignore_ascii_case("Locally Derived") {
         2
-    } else if status.eq_ignore_ascii_case("Inactive Credential") {
+    } else if status.eq_ignore_ascii_case("Invalid Cryptographic Material") {
+        4
+    } else if status.eq_ignore_ascii_case("Inconclusive Validation") {
         3
+    } else if status.eq_ignore_ascii_case("Inactive Credential") {
+        4
     } else if status.eq_ignore_ascii_case("Canary Token (Skipped)")
         || status.eq_ignore_ascii_case("Validation Skipped")
     {
-        4
-    } else if status.eq_ignore_ascii_case("Not Attempted") {
         5
-    } else {
+    } else if status.eq_ignore_ascii_case("Not Attempted") {
         6
+    } else {
+        7
     }
 }
 
@@ -117,6 +123,8 @@ fn validation_status_class(outcome: kingfisher_core::ValidationOutcome) -> &'sta
     match outcome {
         kingfisher_core::ValidationOutcome::VerifiedActive => "status-active",
         kingfisher_core::ValidationOutcome::Assumed => "status-assumed",
+        kingfisher_core::ValidationOutcome::LocallyDerived => "status-local",
+        kingfisher_core::ValidationOutcome::InvalidMaterial => "status-invalid-material",
         kingfisher_core::ValidationOutcome::VerifiedInactive => "status-inactive",
         kingfisher_core::ValidationOutcome::Unavailable => "status-unavailable",
         kingfisher_core::ValidationOutcome::Skipped => "status-canary",
@@ -262,6 +270,8 @@ fn build_html(envelope: &ReportEnvelope) -> String {
     .status {{ padding: 2px 8px; border-radius: 999px; font-weight: 700; }}
     .status-active {{ background: #14532d; color: #86efac; }}
     .status-assumed {{ background: #1e3a8a; color: #bfdbfe; }}
+    .status-local {{ background: #164e63; color: #a5f3fc; }}
+    .status-invalid-material {{ background: #7f1d1d; color: #fecaca; }}
     .status-inactive {{ background: #7f1d1d; color: #fecaca; }}
     .status-canary {{ background: #581c87; color: #e9d5ff; }}
     .status-unavailable {{ background: #7f1d1d; color: #fecaca; }}
@@ -301,8 +311,9 @@ mod tests {
 
     #[test]
     fn skipped_validations_have_a_stable_rank_and_style() {
-        assert_eq!(validation_rank("Canary Token (Skipped)"), 4);
-        assert_eq!(validation_rank("Validation Skipped"), 4);
+        assert_eq!(validation_rank("Canary Token (Skipped)"), 5);
+        assert_eq!(validation_rank("Validation Skipped"), 5);
+        assert_eq!(validation_rank("future validation state"), 7);
         assert_eq!(
             validation_status_class(kingfisher_core::ValidationOutcome::Skipped),
             "status-canary"
@@ -331,6 +342,8 @@ mod tests {
                     findings: 0,
                     active_findings: 0,
                     inactive_findings: 0,
+                    locally_derived_findings: 0,
+                    invalid_material_findings: 0,
                     unknown_validation_findings: 0,
                     access_map_identities: 0,
                     rules_applied: Some(10),

--- a/src/reporter/pretty_format.rs
+++ b/src/reporter/pretty_format.rs
@@ -35,10 +35,14 @@ impl DetailsReporter {
         let validation_outcome = record.finding.validation.outcome;
         let is_active = validation_outcome.is_verified_active();
         let is_high_confidence = validation_outcome == kingfisher_core::ValidationOutcome::Assumed;
+        let is_local = validation_outcome == kingfisher_core::ValidationOutcome::LocallyDerived;
+        let is_actionable = is_active || is_high_confidence || is_local;
         let lock_icon = if is_active {
             "🔓 "
         } else if is_high_confidence {
             "🔒 "
+        } else if is_local {
+            "◇ "
         } else {
             ""
         };
@@ -48,9 +52,7 @@ impl DetailsReporter {
             record.rule.name.to_uppercase(),
             record.rule.id.to_uppercase()
         );
-        if is_active {
-            writeln!(writer, "{}", self.style_finding_active_heading(formatted_heading))?;
-        } else if is_high_confidence {
+        if is_actionable {
             writeln!(writer, "{}", self.style_finding_active_heading(formatted_heading))?;
         } else {
             writeln!(writer, "{}", self.style_finding_heading(formatted_heading))?;
@@ -141,9 +143,9 @@ impl<'a> Display for PrettyFindingRecord<'a> {
         let validation_outcome = record.finding.validation.outcome;
         let is_active = validation_outcome.is_verified_active();
         let is_high_confidence = validation_outcome == kingfisher_core::ValidationOutcome::Assumed;
-        let style_fn: Box<dyn Fn(&str) -> String> = if is_active {
-            Box::new(|s| reporter.style_active_creds(s).to_string())
-        } else if is_high_confidence {
+        let is_local = validation_outcome == kingfisher_core::ValidationOutcome::LocallyDerived;
+        let is_actionable = is_active || is_high_confidence || is_local;
+        let style_fn: Box<dyn Fn(&str) -> String> = if is_actionable {
             Box::new(|s| reporter.style_active_creds(s).to_string())
         } else {
             Box::new(|s| reporter.style_match(s).to_string())
@@ -156,13 +158,7 @@ impl<'a> Display for PrettyFindingRecord<'a> {
         writeln!(f, " |Fingerprint...: {}", finding.fingerprint)?;
         writeln!(f, " |Confidence....: {}", finding.confidence)?;
         writeln!(f, " |Entropy.......: {}", finding.entropy)?;
-        if is_active {
-            writeln!(
-                f,
-                " |Validation....: {}",
-                reporter.style_finding_active_heading(&finding.validation.status)
-            )?;
-        } else if is_high_confidence {
+        if is_actionable {
             writeln!(
                 f,
                 " |Validation....: {}",

--- a/src/reporter/toon_format.rs
+++ b/src/reporter/toon_format.rs
@@ -129,6 +129,8 @@ impl DetailsReporter {
                         findings: envelope.findings.len(),
                         active_findings: 0,
                         inactive_findings: 0,
+                        locally_derived_findings: 0,
+                        invalid_material_findings: 0,
                         unknown_validation_findings: 0,
                         access_map_identities: envelope.access_map.as_ref().map_or(0, Vec::len),
                         rules_applied: None,

--- a/src/scanner/repos.rs
+++ b/src/scanner/repos.rs
@@ -137,6 +137,51 @@ fn apply_repo_clone_limit(
     *repo_urls = limited;
 }
 
+/// Run independent jobs on a bounded Rayon pool and stream successful results
+/// back to the calling thread.
+///
+/// The receiver must stay outside a Rayon scope: Rayon executes a scope's
+/// coordinator closure on a pool worker, so a coordinator that blocks on the
+/// result channel deadlocks when the pool has exactly one worker.
+fn stream_parallel_results<I, O, Items, Worker, Consumer>(
+    num_threads: usize,
+    items: Items,
+    worker: Worker,
+    mut consume: Consumer,
+) -> Result<()>
+where
+    I: Send + 'static,
+    O: Send + 'static,
+    Items: IntoIterator<Item = I>,
+    Worker: Fn(I) -> Option<O> + Send + Sync + 'static,
+    Consumer: FnMut(O),
+{
+    let num_threads = num_threads.max(1);
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .build()
+        .context("Failed to build git clone thread pool")?;
+    let (result_tx, result_rx) = crossbeam_channel::bounded(std::cmp::max(2, num_threads * 2));
+    let worker = Arc::new(worker);
+
+    for item in items {
+        let result_tx = result_tx.clone();
+        let worker = Arc::clone(&worker);
+        pool.spawn(move || {
+            if let Some(result) = worker(item) {
+                let _ = result_tx.send(result);
+            }
+        });
+    }
+    drop(result_tx);
+
+    for result in result_rx {
+        consume(result);
+    }
+
+    Ok(())
+}
+
 pub fn clone_or_update_git_repos_streaming<F>(
     args: &scan::ScanArgs,
     global_args: &global::GlobalArgs,
@@ -180,104 +225,111 @@ where
     };
 
     let clone_concurrency = std::cmp::max(1, args.num_jobs);
-    // Bound this internal channel so cloner workers block on `send` when the
-    // single-threaded dispatcher loop below can't forward fast enough (e.g.
-    // because the outer bounded scan channel is full). Without this bound,
-    // cloners would race ahead and fill `/tmp` with completed-but-unscanned
-    // clones, which is exactly the disk-overflow bug we're trying to fix.
-    let (ready_tx, ready_rx) = crossbeam_channel::bounded(std::cmp::max(2, clone_concurrency * 2));
     let ignore_certs = global_args.ignore_certs;
     let provider_hosts = provider_hosts(args, global_args);
+    let datastore = Arc::clone(datastore);
+    let worker_progress = progress.clone();
 
-    ThreadPoolBuilder::new()
-        .num_threads(clone_concurrency)
-        .build()
-        .context("Failed to build git clone thread pool")?
-        .scope(|scope| {
-            for repo_url in repo_urls {
-                let ready_tx = ready_tx.clone();
-                let datastore = Arc::clone(datastore);
-                let repo_url = repo_url.clone();
-                let progress = progress.clone();
-                let provider_hosts = provider_hosts.clone();
-                scope.spawn(move |_| {
-                    let git = Git::with_provider_hosts(ignore_certs, &provider_hosts);
-                    let output_dir = {
-                        let datastore = datastore.lock().unwrap();
-                        datastore.clone_destination(&repo_url)
-                    };
+    // The helper's bounded result channel prevents cloners from racing ahead
+    // of the scanner and filling the clone directory with completed work.
+    stream_parallel_results(
+        clone_concurrency,
+        repo_urls.iter().cloned(),
+        move |repo_url| {
+            let git = Git::with_provider_hosts(ignore_certs, &provider_hosts);
+            let output_dir = {
+                let datastore = datastore.lock().unwrap();
+                datastore.clone_destination(&repo_url)
+            };
 
-                    if output_dir.is_dir() {
-                        progress.suspend(|| info!("Updating clone of {repo_url}..."));
-                        match git.update_clone(&repo_url, &output_dir) {
-                            Ok(()) => {
-                                {
-                                    let mut ds = datastore.lock().unwrap();
-                                    ds.register_repo_link(output_dir.clone(), repo_url.to_string());
-                                }
-                                let _ = ready_tx.send(output_dir);
-                                progress.inc(1);
-                                return;
-                            }
-                            Err(e) => {
-                                progress.suspend(|| {
-                                    debug!(
-                                        "Failed to update clone of {repo_url} at {}: {e}",
-                                        output_dir.display()
-                                    )
-                                });
-                                if let Err(e) = std::fs::remove_dir_all(&output_dir) {
-                                    progress.suspend(|| {
-                                        debug!(
-                                            "Failed to remove clone directory at {}: {e}",
-                                            output_dir.display()
-                                        )
-                                    });
-                                }
-                            }
+            if output_dir.is_dir() {
+                worker_progress.suspend(|| info!("Updating clone of {repo_url}..."));
+                match git.update_clone(&repo_url, &output_dir) {
+                    Ok(()) => {
+                        {
+                            let mut ds = datastore.lock().unwrap();
+                            ds.register_repo_link(output_dir.clone(), repo_url.to_string());
+                        }
+                        worker_progress.inc(1);
+                        return Some(output_dir);
+                    }
+                    Err(e) => {
+                        worker_progress.suspend(|| {
+                            debug!(
+                                "Failed to update clone of {repo_url} at {}: {e}",
+                                output_dir.display()
+                            )
+                        });
+                        if let Err(e) = std::fs::remove_dir_all(&output_dir) {
+                            worker_progress.suspend(|| {
+                                debug!(
+                                    "Failed to remove clone directory at {}: {e}",
+                                    output_dir.display()
+                                )
+                            });
                         }
                     }
+                }
+            }
 
-                    progress.suspend(|| info!("Cloning {repo_url}..."));
-                    if let Err(e) = git.create_fresh_clone(&repo_url, &output_dir, clone_mode) {
-                        progress.suspend(|| {
-                            if repo_url.as_str().ends_with(".wiki.git") {
-                                info!("Wiki repository not found for {repo_url}, skipping");
-                                debug!(
-                                    "Failed to clone {repo_url} to {}: {e}",
-                                    output_dir.display()
-                                );
-                            } else {
-                                error!(
-                                    "Failed to clone {repo_url} to {}: {e}",
-                                    output_dir.display()
-                                );
-                            }
-                            debug!("Skipping scan of {repo_url}");
-                        });
-                        progress.inc(1);
-                        return;
+            worker_progress.suspend(|| info!("Cloning {repo_url}..."));
+            if let Err(e) = git.create_fresh_clone(&repo_url, &output_dir, clone_mode) {
+                worker_progress.suspend(|| {
+                    if repo_url.as_str().ends_with(".wiki.git") {
+                        info!("Wiki repository not found for {repo_url}, skipping");
+                        debug!("Failed to clone {repo_url} to {}: {e}", output_dir.display());
+                    } else {
+                        error!("Failed to clone {repo_url} to {}: {e}", output_dir.display());
                     }
-
-                    {
-                        let mut ds = datastore.lock().unwrap();
-                        ds.register_repo_link(output_dir.clone(), repo_url.to_string());
-                    }
-
-                    let _ = ready_tx.send(output_dir);
-                    progress.inc(1);
+                    debug!("Skipping scan of {repo_url}");
                 });
+                worker_progress.inc(1);
+                return None;
             }
 
-            drop(ready_tx);
-
-            for repo_root in ready_rx.iter() {
-                on_repo_ready(repo_root);
+            {
+                let mut ds = datastore.lock().unwrap();
+                ds.register_repo_link(output_dir.clone(), repo_url.to_string());
             }
-        });
+
+            worker_progress.inc(1);
+            Some(output_dir)
+        },
+        &mut on_repo_ready,
+    )?;
 
     progress.finish();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::mpsc, thread, time::Duration};
+
+    use super::stream_parallel_results;
+
+    #[test]
+    fn streaming_pool_makes_progress_with_one_worker() {
+        let (done_tx, done_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let mut streamed = Vec::new();
+            let result = stream_parallel_results(
+                1,
+                0..4,
+                |value| Some(value * 2),
+                |value| streamed.push(value),
+            );
+            done_tx.send((result, streamed)).expect("test receiver should remain open");
+        });
+
+        let (result, mut streamed) = done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("one-worker streaming pool should not deadlock");
+        result.expect("streaming jobs should succeed");
+        streamed.sort_unstable();
+        assert_eq!(streamed, vec![0, 2, 4, 6]);
+        handle.join().expect("streaming thread should not panic");
+    }
 }
 
 pub async fn enumerate_github_repos(

--- a/src/scanner/summary.rs
+++ b/src/scanner/summary.rs
@@ -101,7 +101,8 @@ pub fn compute_scan_totals(
                 kingfisher_core::ValidationOutcome::VerifiedActive => {
                     (success + increment, fail, skipped)
                 }
-                kingfisher_core::ValidationOutcome::Assumed => {
+                kingfisher_core::ValidationOutcome::Assumed
+                | kingfisher_core::ValidationOutcome::LocallyDerived => {
                     if actionable_filter {
                         (success + increment, fail, skipped)
                     } else {
@@ -109,6 +110,9 @@ pub fn compute_scan_totals(
                     }
                 }
                 kingfisher_core::ValidationOutcome::VerifiedInactive => {
+                    (success, fail + increment, skipped)
+                }
+                kingfisher_core::ValidationOutcome::InvalidMaterial => {
                     (success, fail + increment, skipped)
                 }
                 kingfisher_core::ValidationOutcome::Skipped => (success, fail, skipped + increment),

--- a/src/scanner/validation.rs
+++ b/src/scanner/validation.rs
@@ -13,11 +13,12 @@ use crossbeam_skiplist::SkipMap;
 use dashmap::DashMap;
 use futures::{FutureExt, StreamExt, stream};
 use indicatif::{ProgressBar, ProgressStyle};
+use kingfisher_core::ValidationOutcome;
 use liquid::Parser;
 use reqwest::StatusCode;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::Notify;
-use tracing::{debug, trace, warn};
+use tracing::{trace, warn};
 
 use crate::{
     access_map::AccessMapRequest,
@@ -507,10 +508,9 @@ pub async fn run_secret_validation(
             // like (?<REGEX>...(ABC|DEF)...), causing all matches to share the same
             // validation result.
             let secret = arc_msg.2.groups.captures.first().map_or("", |c| c.raw_value());
-            let group_key = format!("{}|{}", arc_msg.2.rule.id(), secret);
+            let group_key = validation_group_key(arc_msg.2.rule.id(), secret);
             trace!(
                 rule_id = %arc_msg.2.rule.id(),
-                secret_value = %secret,
                 external_fingerprint = arc_msg.2.finding_fingerprint,
                 validation_group_key = %group_key,
                 "Grouping finding for validation"
@@ -567,7 +567,7 @@ pub async fn run_secret_validation(
                 // VALIDATION DEDUP: Use get(0) for the primary secret value.
                 // See comment above for why this differs from fingerprint/reporting code.
                 let secret = rep_arc.2.groups.captures.first().map_or("", |c| c.raw_value());
-                let key = format!("{}|{}", rep_arc.2.rule.id(), secret);
+                let key = validation_group_key(rep_arc.2.rule.id(), secret);
 
                 match val_res.entry(key.clone()) {
                     dashmap::mapref::entry::Entry::Occupied(_) => return,
@@ -576,6 +576,7 @@ pub async fn run_secret_validation(
                             body: validation_body::from_string(String::new()),
                             status: StatusCode::ACCEPTED,
                             is_valid: false,
+                            outcome: ValidationOutcome::NotAttempted,
                             timestamp: Instant::now(),
                         });
                     }
@@ -610,6 +611,7 @@ pub async fn run_secret_validation(
                     body: om.validation_response_body.clone(),
                     status: om.validation_response_status,
                     is_valid: om.validation_success,
+                    outcome: om.validation_outcome,
                     timestamp: Instant::now(),
                 };
                 val_res.insert(key, cr);
@@ -636,13 +638,13 @@ pub async fn run_secret_validation(
                     continue;
                 }
                 let secret = match_arc.2.groups.captures.first().map_or("", |c| c.raw_value());
-                let key = format!("{}|{}", match_arc.2.rule.id(), secret);
+                let key = validation_group_key(match_arc.2.rule.id(), secret);
                 if let Some(cr) = validation_results.get(&key) {
                     let (_, _, existing) = Arc::make_mut(match_arc);
                     existing.validation_success = cr.is_valid;
                     existing.validation_response_status = cr.status.as_u16();
                     existing.validation_response_body = cr.body.clone();
-                    existing.refresh_validation_outcome();
+                    existing.validation_outcome = cr.outcome;
                 }
             }
         }
@@ -879,12 +881,18 @@ async fn validate_single(
         om.validation_success = cached.is_valid;
         om.validation_response_body = cached.body.clone();
         om.validation_response_status = cached.status;
-        om.refresh_validation_outcome();
+        om.validation_outcome = cached.outcome;
         if om.validation_outcome.is_verified_active()
-            || om.validation_outcome == kingfisher_core::ValidationOutcome::Assumed
+            || matches!(
+                om.validation_outcome,
+                ValidationOutcome::Assumed | ValidationOutcome::LocallyDerived
+            )
         {
             success_count.fetch_add(1, Ordering::Relaxed);
-        } else if om.validation_outcome == kingfisher_core::ValidationOutcome::VerifiedInactive {
+        } else if matches!(
+            om.validation_outcome,
+            ValidationOutcome::VerifiedInactive | ValidationOutcome::InvalidMaterial
+        ) {
             fail_count.fetch_add(1, Ordering::Relaxed);
         }
         maybe_record_access_map(om, access_map);
@@ -903,13 +911,18 @@ async fn validate_single(
             om.validation_success = cached.is_valid;
             om.validation_response_body = cached.body.clone();
             om.validation_response_status = cached.status;
-            om.refresh_validation_outcome();
+            om.validation_outcome = cached.outcome;
             if om.validation_outcome.is_verified_active()
-                || om.validation_outcome == kingfisher_core::ValidationOutcome::Assumed
+                || matches!(
+                    om.validation_outcome,
+                    ValidationOutcome::Assumed | ValidationOutcome::LocallyDerived
+                )
             {
                 success_count.fetch_add(1, Ordering::Relaxed);
-            } else if om.validation_outcome == kingfisher_core::ValidationOutcome::VerifiedInactive
-            {
+            } else if matches!(
+                om.validation_outcome,
+                ValidationOutcome::VerifiedInactive | ValidationOutcome::InvalidMaterial
+            ) {
                 fail_count.fetch_add(1, Ordering::Relaxed);
             }
             maybe_record_access_map(om, access_map);
@@ -957,16 +970,15 @@ enum ValidationRunOutcome {
     /// Validation ran to completion; the match's own fields describe whether it
     /// succeeded or failed.
     Completed,
-    /// Validation panicked. The payload is captured for logging only and must
-    /// never be surfaced to the user or cache (it may embed secret material).
-    Panicked(String),
+    /// Validation panicked. The payload is discarded because it may contain secrets.
+    Panicked,
 }
 
 impl ValidationRunOutcome {
-    fn from_panic_result(result: std::result::Result<(), String>) -> Self {
+    fn from_panic_result(result: std::result::Result<(), ()>) -> Self {
         match result {
             Ok(()) => ValidationRunOutcome::Completed,
-            Err(panic_message) => ValidationRunOutcome::Panicked(panic_message),
+            Err(()) => ValidationRunOutcome::Panicked,
         }
     }
 }
@@ -983,11 +995,16 @@ fn apply_validation_outcome(
         ValidationRunOutcome::Completed => {
             om.refresh_validation_outcome();
             if om.validation_outcome.is_verified_active()
-                || om.validation_outcome == kingfisher_core::ValidationOutcome::Assumed
+                || matches!(
+                    om.validation_outcome,
+                    ValidationOutcome::Assumed | ValidationOutcome::LocallyDerived
+                )
             {
                 success_count.fetch_add(1, Ordering::Relaxed);
-            } else if om.validation_outcome == kingfisher_core::ValidationOutcome::VerifiedInactive
-            {
+            } else if matches!(
+                om.validation_outcome,
+                ValidationOutcome::VerifiedInactive | ValidationOutcome::InvalidMaterial
+            ) {
                 fail_count.fetch_add(1, Ordering::Relaxed);
             }
             cache.insert(
@@ -996,23 +1013,15 @@ fn apply_validation_outcome(
                     is_valid: om.validation_success,
                     status: om.validation_response_status,
                     body: om.validation_response_body.clone(),
+                    outcome: om.validation_outcome,
                     timestamp: Instant::now(),
                 },
             );
         }
-        ValidationRunOutcome::Panicked(panic_message) => {
-            // The panic payload can embed secret material (e.g. a token captured
-            // in a debug string), so it must never reach the cached or
-            // user-visible body. Keep WARN free of the payload too; truncated
-            // panic detail is only emitted at DEBUG for troubleshooting.
+        ValidationRunOutcome::Panicked => {
             warn!(
                 rule_id = %om.rule.id(),
                 "validator panicked; marking match as failed",
-            );
-            debug!(
-                rule_id = %om.rule.id(),
-                panic = %truncate_for_log(&panic_message),
-                "validator panic detail",
             );
             om.validation_success = false;
             om.validation_response_body = validation_body::from_string(format!(
@@ -1027,6 +1036,7 @@ fn apply_validation_outcome(
                     is_valid: om.validation_success,
                     status: om.validation_response_status,
                     body: om.validation_response_body.clone(),
+                    outcome: om.validation_outcome,
                     timestamp: Instant::now(),
                 },
             );
@@ -1043,8 +1053,8 @@ fn is_counted_validation_status(status: StatusCode) -> bool {
 ///
 /// Validators perform network I/O and parse untrusted responses, so a stray
 /// `panic!`/`unwrap` would otherwise tear down the entire scan. We catch the
-/// unwind here and surface it as `Err(message)` so the caller can fail just the
-/// one match.
+/// unwind here and fail just the one match. The panic payload is discarded
+/// immediately because it may contain secret material.
 ///
 /// `AssertUnwindSafe` is required because the future borrows `&mut om`. It is
 /// sound for this use because the unwind is never observed as a partial result:
@@ -1053,45 +1063,23 @@ fn is_counted_validation_status(status: StatusCode) -> bool {
 /// `validation_response_body`) with a deterministic failure state. The shared
 /// counters and response cache are only mutated *after* this boundary returns,
 /// so a panic cannot leave them inconsistent.
-async fn catch_validation_panic<F>(future: F) -> std::result::Result<(), String>
+async fn catch_validation_panic<F>(future: F) -> std::result::Result<(), ()>
 where
     F: Future<Output = ()>,
 {
     match AssertUnwindSafe(future).catch_unwind().await {
         Ok(()) => Ok(()),
-        Err(payload) => Err(describe_panic_payload(payload)),
+        Err(_payload) => Err(()),
     }
-}
-
-fn describe_panic_payload(payload: Box<dyn std::any::Any + Send>) -> String {
-    if let Some(message) = payload.downcast_ref::<&str>() {
-        (*message).to_string()
-    } else if let Some(message) = payload.downcast_ref::<String>() {
-        message.clone()
-    } else {
-        "non-string panic payload".to_string()
-    }
-}
-
-/// Bound a panic message before it reaches the logs. Panic payloads are
-/// unbounded in length and may be influenced by scanned content, so cap them at
-/// a fixed length on a UTF-8 boundary.
-fn truncate_for_log(message: &str) -> String {
-    const MAX_LEN: usize = 256;
-    if message.len() <= MAX_LEN {
-        return message.to_string();
-    }
-    let mut end = MAX_LEN;
-    while !message.is_char_boundary(end) {
-        end -= 1;
-    }
-    format!("{}… (truncated)", &message[..end])
 }
 
 // Helper to compute the cache key for an OwnedBlobMatch.
 fn build_cache_key(om: &OwnedBlobMatch) -> String {
-    let capture0 =
-        om.captures.captures.first().map_or(String::new(), |c| c.raw_value().to_string());
+    let capture0 = om.captures.captures.first().map_or("", |c| c.raw_value());
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"kingfisher.validation-cache.v1\0");
+    hash_cache_key_part(&mut hasher, om.rule.id().as_bytes());
+    hash_cache_key_part(&mut hasher, capture0.as_bytes());
 
     let has_context_dependency = om
         .rule
@@ -1101,17 +1089,25 @@ fn build_cache_key(om: &OwnedBlobMatch) -> String {
         .flatten()
         .any(|dep| !dep.variable.eq_ignore_ascii_case("TOKEN"));
     if has_context_dependency {
-        return format!(
-            "{}|{}|{}|{}|{}",
-            om.rule.name(),
-            capture0,
-            om.blob_id,
-            om.matching_input_offset_span.start,
-            om.matching_input_offset_span.end
-        );
+        hash_cache_key_part(&mut hasher, om.blob_id.to_string().as_bytes());
+        hash_cache_key_part(&mut hasher, &om.matching_input_offset_span.start.to_le_bytes());
+        hash_cache_key_part(&mut hasher, &om.matching_input_offset_span.end.to_le_bytes());
     }
 
-    format!("{}|{}", om.rule.name(), capture0)
+    hasher.finalize().to_hex().to_string()
+}
+
+fn validation_group_key(rule_id: &str, secret: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"kingfisher.validation-group.v1\0");
+    hash_cache_key_part(&mut hasher, rule_id.as_bytes());
+    hash_cache_key_part(&mut hasher, secret.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+fn hash_cache_key_part(hasher: &mut blake3::Hasher, part: &[u8]) {
+    hasher.update(&(part.len() as u64).to_le_bytes());
+    hasher.update(part);
 }
 
 fn maybe_record_access_map(om: &OwnedBlobMatch, collector: Option<&AccessMapCollector>) {
@@ -1826,13 +1822,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn catch_validation_panic_returns_panic_message() {
+    async fn catch_validation_panic_discards_panic_message() {
         let result = catch_validation_panic(async {
             panic!("validator blew up");
         })
         .await;
 
-        assert_eq!(result.unwrap_err(), "validator blew up");
+        assert_eq!(result.unwrap_err(), ());
     }
 
     #[tokio::test]

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::BTreeMap,
     fs,
-    hash::{Hash, Hasher},
     panic::AssertUnwindSafe,
     sync::Arc,
     time::{Duration, Instant},
@@ -13,12 +12,13 @@ use anyhow::Result;
 use dashmap::DashMap;
 use futures::FutureExt;
 use http::StatusCode;
+use kingfisher_core::ValidationOutcome;
 use liquid::Object;
 use liquid_core::{Value, ValueView};
 use reqwest::{Client, Url, header, header::HeaderValue, multipart};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::{sync::Notify, time};
-use tracing::{debug, trace, warn};
+use tracing::{debug, warn};
 
 use crate::{
     cli::global::TlsMode,
@@ -258,7 +258,7 @@ impl ValidationClients {
 // Use SkipMap-based cache instead of a mutex-wrapped FxHashMap.
 type Cache = kingfisher_scanner::validation::Cache;
 
-/// Returns an opaque 64-bit key for internal validation deduplication.
+/// Returns an opaque key for internal validation deduplication.
 ///
 /// This is an INTERNAL key used only for validation deduplication within a single scan.
 /// It uses `captures.get(0)` to get the primary secret value. Rules with dependent
@@ -272,51 +272,48 @@ type Cache = kingfisher_scanner::validation::Cache;
 ///
 /// The external fingerprint uses `get(1).or_else(get(0))` for backward compatibility
 /// and must remain stable. This internal key can evolve independently.
-fn validation_dedup_key(m: &OwnedBlobMatch) -> u64 {
-    let mut hasher = xxhash_rust::xxh3::Xxh3::new();
-    m.rule.syntax().id.hash(&mut hasher);
+fn validation_dedup_key(m: &OwnedBlobMatch) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"kingfisher.validation-dedup.v1\0");
+    hash_key_part(&mut hasher, m.rule.syntax().id.as_bytes());
 
     // Use the first capture (primary secret) for deduplication.
-    // Note: capture_value is stored in a variable because it's also used in trace! below.
     let capture_value = m.captures.captures.first().map(|c| c.raw_value());
     if let Some(val) = capture_value {
-        val.hash(&mut hasher);
+        hash_key_part(&mut hasher, val.as_bytes());
     }
 
     if !m.rule.syntax().depends_on_rule.is_empty() {
-        m.blob_id.hash(&mut hasher);
-        m.matching_input_offset_span.start.hash(&mut hasher);
-        m.matching_input_offset_span.end.hash(&mut hasher);
+        hash_key_part(&mut hasher, m.blob_id.to_string().as_bytes());
+        hash_key_part(&mut hasher, &m.matching_input_offset_span.start.to_le_bytes());
+        hash_key_part(&mut hasher, &m.matching_input_offset_span.end.to_le_bytes());
     }
 
-    let key = hasher.finish();
-
-    trace!(
-        rule_id = %m.rule.syntax().id,
-        capture_value = ?capture_value,
-        validation_dedup_key = key,
-        "Computed internal validation dedup key"
-    );
-
-    key
+    *hasher.finalize().as_bytes()
 }
 
-static VALIDATION_CACHE: OnceLock<DashMap<u64, CachedResponse>> = OnceLock::new();
-static IN_FLIGHT: OnceLock<DashMap<u64, Arc<Notify>>> = OnceLock::new();
+fn hash_key_part(hasher: &mut blake3::Hasher, part: &[u8]) {
+    hasher.update(&(part.len() as u64).to_le_bytes());
+    hasher.update(part);
+}
 
-fn cache_validation_result(fp: u64, m: &OwnedBlobMatch) {
+static VALIDATION_CACHE: OnceLock<DashMap<[u8; 32], CachedResponse>> = OnceLock::new();
+static IN_FLIGHT: OnceLock<DashMap<[u8; 32], Arc<Notify>>> = OnceLock::new();
+
+fn cache_validation_result(fp: [u8; 32], m: &OwnedBlobMatch) {
     VALIDATION_CACHE.get_or_init(DashMap::new).insert(
         fp,
         CachedResponse {
             body: m.validation_response_body.clone(),
             status: m.validation_response_status,
             is_valid: m.validation_success,
+            outcome: m.validation_outcome,
             timestamp: Instant::now(),
         },
     );
 }
 
-fn clear_in_flight_validation(fp: u64) {
+fn clear_in_flight_validation(fp: [u8; 32]) {
     if let Some((_, notify)) = IN_FLIGHT.get_or_init(DashMap::new).remove(&fp) {
         notify.notify_waiters();
     }
@@ -564,6 +561,7 @@ async fn timed_validate_single_match(
         m.validation_success = entry.is_valid;
         m.validation_response_body = entry.body.clone();
         m.validation_response_status = entry.status;
+        m.validation_outcome = entry.outcome;
         return;
     }
     if let Some(wait) =
@@ -574,6 +572,7 @@ async fn timed_validate_single_match(
             m.validation_success = entry.is_valid;
             m.validation_response_body = entry.body.clone();
             m.validation_response_status = entry.status;
+            m.validation_outcome = entry.outcome;
         }
         return;
     }
@@ -679,6 +678,26 @@ async fn timed_validate_single_match(
     match &validation {
         Some(Validation::Assumed) => {
             // Assumed validation intentionally produces no live validation result.
+        }
+        Some(Validation::Ethereum(kind)) => {
+            let token = captured_values
+                .iter()
+                .find(|(name, ..)| name.eq_ignore_ascii_case("TOKEN"))
+                .or_else(|| captured_values.first())
+                .map(|(_, value, ..)| value.as_str());
+            if let Some(token) = token {
+                let result = kingfisher_scanner::validation::ethereum::validate(*kind, token);
+                m.validation_success = false;
+                m.validation_response_body = validation_body::from_string(result.body);
+                m.validation_response_status = StatusCode::CONTINUE;
+                m.validation_outcome = result.outcome;
+            } else {
+                m.validation_success = false;
+                m.validation_response_body =
+                    validation_body::from_string("Ethereum validation requires TOKEN capture");
+                m.validation_response_status = StatusCode::BAD_REQUEST;
+                m.validation_outcome = ValidationOutcome::Unavailable;
+            }
         }
         Some(Validation::Http(http_validation)) => {
             validate_http(
@@ -1001,6 +1020,11 @@ async fn validate_http(
                         body: body_opt,
                         status,
                         is_valid: m.validation_success,
+                        outcome: ValidationOutcome::from_legacy(
+                            false,
+                            m.validation_success,
+                            status.as_u16(),
+                        ),
                         timestamp: Instant::now(),
                     },
                 );
@@ -1207,6 +1231,11 @@ async fn validate_mysql_rule(
             body: m.validation_response_body.clone(),
             status: m.validation_response_status,
             is_valid: m.validation_success,
+            outcome: ValidationOutcome::from_legacy(
+                false,
+                m.validation_success,
+                m.validation_response_status.as_u16(),
+            ),
             timestamp: Instant::now(),
         },
     );
@@ -1268,6 +1297,11 @@ async fn validate_azure_storage(
             body: m.validation_response_body.clone(),
             status: m.validation_response_status,
             is_valid: m.validation_success,
+            outcome: ValidationOutcome::from_legacy(
+                false,
+                m.validation_success,
+                m.validation_response_status.as_u16(),
+            ),
             timestamp: Instant::now(),
         },
     );
@@ -1324,6 +1358,11 @@ async fn validate_jdbc_rule(
             body: m.validation_response_body.clone(),
             status: m.validation_response_status,
             is_valid: m.validation_success,
+            outcome: ValidationOutcome::from_legacy(
+                false,
+                m.validation_success,
+                m.validation_response_status.as_u16(),
+            ),
             timestamp: Instant::now(),
         },
     );
@@ -1384,6 +1423,11 @@ async fn validate_postgres_rule(
             body: m.validation_response_body.clone(),
             status: m.validation_response_status,
             is_valid: m.validation_success,
+            outcome: ValidationOutcome::from_legacy(
+                false,
+                m.validation_success,
+                m.validation_response_status.as_u16(),
+            ),
             timestamp: Instant::now(),
         },
     );
@@ -1503,6 +1547,7 @@ async fn validate_aws_rule(
                     body: body.clone(),
                     status: StatusCode::PRECONDITION_REQUIRED,
                     is_valid: false,
+                    outcome: ValidationOutcome::Skipped,
                     timestamp: Instant::now(),
                 },
             );
@@ -1520,6 +1565,7 @@ async fn validate_aws_rule(
                     body: body.clone(),
                     status: StatusCode::BAD_REQUEST,
                     is_valid: false,
+                    outcome: ValidationOutcome::Unavailable,
                     timestamp: Instant::now(),
                 },
             );
@@ -1544,6 +1590,7 @@ async fn validate_aws_rule(
                             body: m.validation_response_body.clone(),
                             status: m.validation_response_status,
                             is_valid: true,
+                            outcome: ValidationOutcome::VerifiedActive,
                             timestamp: Instant::now(),
                         },
                     );
@@ -1560,6 +1607,7 @@ async fn validate_aws_rule(
                         body: body.clone(),
                         status: StatusCode::UNAUTHORIZED,
                         is_valid: false,
+                        outcome: ValidationOutcome::VerifiedInactive,
                         timestamp: Instant::now(),
                     },
                 );
@@ -1685,6 +1733,11 @@ async fn validate_gcp_rule(m: &mut OwnedBlobMatch, globals: &Object, cache: &Cac
             body: m.validation_response_body.clone(),
             status: m.validation_response_status,
             is_valid: m.validation_success,
+            outcome: ValidationOutcome::from_legacy(
+                false,
+                m.validation_success,
+                m.validation_response_status.as_u16(),
+            ),
             timestamp: Instant::now(),
         },
     );

--- a/src/validation_rate_limit.rs
+++ b/src/validation_rate_limit.rs
@@ -118,7 +118,7 @@ fn selector_matches(rule_id: &str, selector: &str) -> bool {
 }
 
 pub fn should_rate_limit_validation(validation: &Validation) -> bool {
-    !matches!(validation, Validation::Assumed)
+    !matches!(validation, Validation::Assumed | Validation::Ethereum(_))
 }
 
 #[cfg(test)]
@@ -168,6 +168,9 @@ mod tests {
     #[test]
     fn should_rate_limit_non_http_validators() {
         assert!(should_rate_limit_validation(&Validation::AWS));
+        assert!(!should_rate_limit_validation(&Validation::Ethereum(
+            kingfisher_rules::EthereumValidation::PrivateKey
+        )));
         assert!(should_rate_limit_validation(&Validation::GCP));
         assert!(should_rate_limit_validation(&Validation::MongoDB));
         assert!(should_rate_limit_validation(&Validation::Postgres));

--- a/tests/int_ethereum_rules.rs
+++ b/tests/int_ethereum_rules.rs
@@ -1,0 +1,155 @@
+use std::fs;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::tempdir;
+
+const ANVIL_PRIVATE_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const ANVIL_MNEMONIC: &str = "test test test test test test test test test test test junk";
+const ANVIL_ADDRESS: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+#[test]
+fn ethereum_rules_derive_addresses_without_claiming_live_activity() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("fixture.txt");
+    let report_path = temp.path().join("report.json");
+    fs::write(
+        &input,
+        format!(
+            "ETHEREUM_PRIVATE_KEY={ANVIL_PRIVATE_KEY}\n\
+             ETHEREUM_MNEMONIC=\"{ANVIL_MNEMONIC}\"\n"
+        ),
+    )
+    .unwrap();
+
+    let output = Command::new(assert_cmd::cargo::cargo_bin!("kingfisher"))
+        .args([
+            "scan",
+            input.to_str().unwrap(),
+            "--git-history",
+            "none",
+            "--rule",
+            "kingfisher.ethereum.1",
+            "--rule",
+            "kingfisher.ethereum.2",
+            "--format",
+            "json",
+            "--output",
+            report_path.to_str().unwrap(),
+            "--no-update-check",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(200), "{}", String::from_utf8_lossy(&output.stderr));
+    let report_text = fs::read_to_string(report_path).unwrap();
+
+    let report: Value = serde_json::from_str(&report_text).unwrap();
+    let findings = report["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 2);
+    for finding in findings {
+        assert_eq!(finding["finding"]["validation"]["outcome"], "locally_derived");
+        assert_eq!(finding["finding"]["validation"]["status"], "Locally Derived");
+        let response = finding["finding"]["validation"]["response"].as_str().unwrap();
+        assert!(!response.contains(ANVIL_PRIVATE_KEY));
+        assert!(!response.contains(ANVIL_MNEMONIC));
+        let evidence: Value = serde_json::from_str(response).unwrap();
+        assert_eq!(evidence["derived_address"], ANVIL_ADDRESS);
+    }
+    assert_eq!(report["metadata"]["summary"]["locally_derived_findings"], 2);
+    assert_eq!(report["metadata"]["summary"]["active_findings"], 0);
+    assert_eq!(report["metadata"]["summary"]["successful_validations"], 0);
+    assert_eq!(report["metadata"]["summary"]["skipped_validations"], 2);
+}
+
+#[test]
+fn direct_validation_exposes_local_outcome_and_sanitized_evidence() {
+    let output = Command::new(assert_cmd::cargo::cargo_bin!("kingfisher"))
+        .args([
+            "validate",
+            "--rule",
+            "kingfisher.ethereum.1",
+            "--format",
+            "json",
+            "--no-update-check",
+            ANVIL_PRIVATE_KEY,
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.contains(ANVIL_PRIVATE_KEY));
+    let result: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(result["validation_outcome"], "locally_derived");
+    let evidence: Value = serde_json::from_str(result["message"].as_str().unwrap()).unwrap();
+    assert_eq!(evidence["derived_address"], ANVIL_ADDRESS);
+}
+
+#[test]
+fn generic_bip39_detection_is_checksum_gated_and_chain_neutral() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("fixture.txt");
+    let report_path = temp.path().join("report.json");
+    fs::write(
+        &input,
+        "seed_phrase=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\n\
+         mnemonic=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon\n",
+    )
+    .unwrap();
+
+    let output = Command::new(assert_cmd::cargo::cargo_bin!("kingfisher"))
+        .args([
+            "scan",
+            input.to_str().unwrap(),
+            "--git-history",
+            "none",
+            "--rule",
+            "kingfisher.bip39.1",
+            "--format",
+            "json",
+            "--output",
+            report_path.to_str().unwrap(),
+            "--no-update-check",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(200), "{}", String::from_utf8_lossy(&output.stderr));
+    let report: Value = serde_json::from_slice(&fs::read(report_path).unwrap()).unwrap();
+    assert_eq!(report["findings"].as_array().unwrap().len(), 1);
+    assert_eq!(report["findings"][0]["rule"]["id"], "kingfisher.bip39.1");
+}
+
+#[test]
+fn invalid_curve_material_has_its_own_non_actionable_outcome() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("fixture.txt");
+    let report_path = temp.path().join("report.json");
+    // secp256k1's group order is not a valid private scalar.
+    let invalid_private_key = "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141";
+    fs::write(&input, format!("ETHEREUM_PRIVATE_KEY={invalid_private_key}\n")).unwrap();
+
+    let output = Command::new(assert_cmd::cargo::cargo_bin!("kingfisher"))
+        .args([
+            "scan",
+            input.to_str().unwrap(),
+            "--git-history",
+            "none",
+            "--rule",
+            "kingfisher.ethereum.1",
+            "--format",
+            "json",
+            "--output",
+            report_path.to_str().unwrap(),
+            "--no-update-check",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(matches!(output.status.code(), Some(0 | 200)));
+    let report: Value = serde_json::from_slice(&fs::read(report_path).unwrap()).unwrap();
+    assert_eq!(report["findings"][0]["finding"]["validation"]["outcome"], "invalid_material");
+    assert_eq!(report["metadata"]["summary"]["invalid_material_findings"], 1);
+    assert_eq!(report["metadata"]["summary"]["failed_validations"], 1);
+}


### PR DESCRIPTION
This pull request introduces deterministic, network-free Ethereum key and BIP-39 mnemonic detection and validation, along with improvements to validation outcomes and internal security. The changes include new rules for Ethereum private keys and mnemonics, a reusable BIP-39 checksum filter, and explicit reporting of local cryptographic validation results. The update also hardens validation caching and panic handling to prevent secret exposure and fixes a hang in remote Git URL scans.

**Ethereum and BIP-39 Key Detection and Validation:**

- Added new rules for detecting Ethereum private keys, public keys, and BIP-39 seed phrases, including support for Ethereum-specific mnemonics. These rules leverage local cryptographic validation to determine if detected material is structurally valid. (`crates/kingfisher-rules/data/rules/ethereum.yml`, `crates/kingfisher-rules/data/rules/bip39.yml`) [[1]](diffhunk://#diff-e4c55c5029f0199f94eaff395e3e86e9a800c4ba345600206fefd9cdb182bc9cR1-R155) [[2]](diffhunk://#diff-3b66c75c20d37493b468d18e080fffb250c97da679ffff698c4011d51a25a17eR1-R53)
- Introduced a reusable `bip39_valid` Liquid filter for checksum validation of BIP-39 mnemonics, with comprehensive tests for standard and edge cases. (`crates/kingfisher-rules/src/liquid_filters.rs`) [[1]](diffhunk://#diff-26bb9d129d373a554cb90fb91ce6e2494bb2b2fbfa57aece10c3ec5011b5cbc4R528-R547) [[2]](diffhunk://#diff-26bb9d129d373a554cb90fb91ce6e2494bb2b2fbfa57aece10c3ec5011b5cbc4R1410-R1437)

**Validation Outcome and Reporting Improvements:**

- Extended `ValidationOutcome` to explicitly represent locally derived (network-free) cryptographic validation results and invalid material, with corresponding serialization and display names. (`crates/kingfisher-core/src/validation.rs`) [[1]](diffhunk://#diff-b57b208571f4e9619aaf846f7b9d120a6228650a68cab63aab08e90e3f955351L32-R36) [[2]](diffhunk://#diff-b57b208571f4e9619aaf846f7b9d120a6228650a68cab63aab08e90e3f955351L52-R65) [[3]](diffhunk://#diff-b57b208571f4e9619aaf846f7b9d120a6228650a68cab63aab08e90e3f955351R103-R104) [[4]](diffhunk://#diff-b57b208571f4e9619aaf846f7b9d120a6228650a68cab63aab08e90e3f955351R134-R141)
- Updated actionable validation logic to include locally derived outcomes, improving reporting accuracy. (`crates/kingfisher-core/src/validation.rs`)

**Validation Infrastructure and Security:**

- Added support for deterministic Ethereum key validation as a feature-gated dependency, including new workspace dependencies and feature flags. (`Cargo.toml`, `crates/kingfisher-scanner/Cargo.toml`, `crates/kingfisher-scanner/src/lib.rs`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R21-R22) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R38) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R49-R54) [[4]](diffhunk://#diff-1bd728aadd743b9b405d529d969c3d912e8ac092110e6c61749f651d3855187bR40) [[5]](diffhunk://#diff-1bd728aadd743b9b405d529d969c3d912e8ac092110e6c61749f651d3855187bR50) [[6]](diffhunk://#diff-b7b33f9d38cbcd5ecd1b425ec0ba76e3ba68cee7e6304f75e7e22dbf48359355R46-R54) [[7]](diffhunk://#diff-b7b33f9d38cbcd5ecd1b425ec0ba76e3ba68cee7e6304f75e7e22dbf48359355R124) [[8]](diffhunk://#diff-b7b33f9d38cbcd5ecd1b425ec0ba76e3ba68cee7e6304f75e7e22dbf48359355R179-R184) [[9]](diffhunk://#diff-e8d911650e9a02bb08b9372770d555c10d80483b6bdf0bf3990db041b50b9a23R51)
- Hardened validation caching and panic handling to avoid secret exposure. (`CHANGELOG.md`)

**Other Fixes and Updates:**

- Fixed an issue where remote Git URL scans could hang when running with `--jobs 1`. (`CHANGELOG.md`)
- Bumped version to `v1.112.0` and updated changelog to reflect these changes. (`Cargo.toml`, `CHANGELOG.md`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R49-R54) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R9)