### PR TITLE
docs: mention MegaLinter availability in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Kingfisher supports multiple installation methods:
 - **Install scripts**: One-line installers for Linux, macOS, and Windows - [INSTALLATION.md](docs/INSTALLATION.md)
 - **Docker**: `docker run ghcr.io/mongodb/kingfisher:latest`
 - **Pre-commit hooks**: Integrate with git hooks, pre-commit framework, or Husky
+- **MegaLinter**: Kingfisher is bundled in [MegaLinter](https://megalinter.io/latest/descriptors/repository_kingfisher/), so CI pipelines using it get Kingfisher scans out of the box
 - **Compile from source**: Build with `make` for your platform
 
 **For complete installation instructions and pre-commit hook setup, see [docs/INSTALLATION.md](docs/INSTALLATION.md).**


### PR DESCRIPTION
Hi! Kingfisher ships as one of the security linters in [MegaLinter](https://megalinter.io) (descriptor page: https://megalinter.io/latest/descriptors/repository_kingfisher/), so people already running MegaLinter in CI get Kingfisher for free.

This just adds a one-line bullet to the Installation list in the README so folks know about that option. Happy to tweak wording or move it elsewhere if you prefer!