### PR TITLE
Add Hugging Face token revocation

### DIFF
--- a/crates/kingfisher-rules/data/rules/huggingface.yml
+++ b/crates/kingfisher-rules/data/rules/huggingface.yml
@@ -12,6 +12,7 @@ rules:
       \b
     references:
       - https://huggingface.co/docs/hub/security-tokens
+      - https://huggingface.co/docs/hub/main/en/security-tokens#revoking-a-leaked-token
       - https://github.com/praetorian-inc/noseyparker/blob/2e6e7f36ce36619852532bbe698d8cb7a26d2da7/crates/noseyparker/data/default/builtin/rules/huggingface.yml
       - https://github.com/gitleaks/gitleaks/blob/b58d3f102cf3a2c84cb7f923d05c25c9b1aed84b/cmd/generate/config/rules/huggingface.go
       - https://github.com/projectdiscovery/nuclei-templates/blob/a165bbb8fd498d7dc59b755d8d5ba7561ac6f0c5/http/exposures/tokens/huggingface/huggingface-user-access-token.yaml
@@ -41,3 +42,16 @@ rules:
                 - '"name":'
                 - '"id":'
           url: https://huggingface.co/api/whoami-v2
+    revocation:
+      type: Http
+      content:
+        request:
+          method: POST
+          url: https://huggingface.co/api/credentials/revoke
+          headers:
+            Content-Type: application/json
+          body: '{"credentials":["{{ TOKEN }}"]}'
+          response_matcher:
+            - report_response: true
+            - type: StatusMatch
+              status: [202]


### PR DESCRIPTION
## Summary
- Add YAML `revocation` for `kingfisher.huggingface.1` using Hugging Face's public leaked-token revoke endpoint (`POST https://huggingface.co/api/credentials/revoke`).
- Expect `202 Accepted`, matching [Hugging Face's documented behavior](https://huggingface.co/docs/hub/main/en/security-tokens#revoking-a-leaked-token) (always returns 202 whether or not submitted credentials existed).
- Add a reference link to the revoke documentation.

## Test plan
- [x] `cargo test -p kingfisher-rules`
- [x] `kingfisher rules check --rules-path crates/kingfisher-rules/data/rules/huggingface.yml --load-builtins=false --no-update-check`
- [ ] Optionally exercise live revoke against a throwaway HF token with `kingfisher revoke` / equivalent CLI flow


Made with [Cursor](https://cursor.com)