### PR TITLE
Fix failing PyPI build

### DIFF
--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -41,5 +41,6 @@ only-include = [
   "kingfisher",
   "README.md",
 ]
+core-metadata-version = "2.4"
 
 [tool.hatch.build.targets.wheel.hooks.custom]


### PR DESCRIPTION
This pull request makes a minor configuration update to the `pyproject.toml` file, specifying the `core-metadata-version` for the build process. This ensures compatibility with tools that rely on this metadata version. 

* Set `core-metadata-version` to `"2.4"` in `pyproject.toml` to explicitly define the metadata version used in package builds.