### PR TITLE
v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ NOTE: Replay has been slowed down for demo
 
 - [AWS, GCP, and More: Blast-Radius Mapping Included by Default](#aws-gcp-and-more-blast-radius-mapping-included-by-default)
 - [What Is Kingfisher?](#what-is-kingfisher)
-- [Why Choose Kingfisher?](#why-choose-kingfisher)
 - [Key Features](#key-features)
 - [Report Viewer (local and hosted)](#report-viewer-local-and-hosted)
 - [Alert Webhooks](#alert-webhooks)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ NOTE: Replay has been slowed down for demo
 
 - [AWS, GCP, and More: Blast-Radius Mapping Included by Default](#aws-gcp-and-more-blast-radius-mapping-included-by-default)
 - [What Is Kingfisher?](#what-is-kingfisher)
+- [Why Choose Kingfisher?](#why-choose-kingfisher)
 - [Key Features](#key-features)
 - [Report Viewer (local and hosted)](#report-viewer-local-and-hosted)
 - [Alert Webhooks](#alert-webhooks)

--- a/src/github.rs
+++ b/src/github.rs
@@ -773,7 +773,7 @@ pub async fn list_repositories(
 
 fn parse_repo(repo_url: &GitUrl) -> Option<(String, String, String)> {
     let url = Url::parse(repo_url.as_str()).ok()?;
-    let host = url.host_str()?.to_string();
+    let host = url[url::Position::BeforeHost..url::Position::AfterPort].to_string();
     let mut segments = url.path_segments()?;
     let owner = segments.next()?.to_string();
     let mut repo = segments.next()?.to_string();
@@ -1029,6 +1029,24 @@ mod tests {
             "https://ghe.example.com/gist/abc123"
         );
         assert_eq!(fallback_gist_url("github.com", "abc123"), "https://gist.github.com/abc123");
+    }
+
+    #[test]
+    fn github_enterprise_urls_preserve_non_default_ports() {
+        let repo_url = GitUrl::from_str("https://ghe.example.com:8443/acme/widgets.git").unwrap();
+
+        assert_eq!(
+            parse_repo(&repo_url),
+            Some(("ghe.example.com:8443".to_string(), "acme".to_string(), "widgets".to_string(),))
+        );
+        assert_eq!(
+            wiki_url(&repo_url).unwrap().as_str(),
+            "https://ghe.example.com:8443/acme/widgets.wiki.git"
+        );
+        assert_eq!(
+            fallback_gist_url("ghe.example.com:8443", "abc123"),
+            "https://ghe.example.com:8443/gist/abc123"
+        );
     }
 
     #[test]

--- a/tests/library_crates_external_project.rs
+++ b/tests/library_crates_external_project.rs
@@ -98,7 +98,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let output = Command::new("cargo")
         .arg("run")
         .arg("--quiet")
-        .arg("--frozen")
+        // The external dependency graph can include packages that the workspace build did not
+        // download. Keep its generated lockfile fixed without requiring a warm Cargo cache.
+        .arg("--locked")
         .current_dir(&project_dir)
         .output()?;
 


### PR DESCRIPTION
This pull request includes several improvements and fixes related to repository URL parsing, test coverage, documentation, and build process robustness. The main focus is on ensuring non-default ports in GitHub Enterprise URLs are correctly handled and tested, updating documentation, and refining the build command for external projects.

**Repository URL handling and test coverage:**

* Updated `parse_repo` in `src/github.rs` to correctly preserve non-default ports in repository hostnames, ensuring compatibility with GitHub Enterprise instances.
* Added a new test to verify that non-default ports are preserved in repository URLs and related functions, improving reliability for enterprise setups.

**Build process improvements:**

* Changed the cargo run argument from `--frozen` to `--locked` in `tests/library_crates_external_project.rs` to better handle dependency management for external projects.